### PR TITLE
refactor: props 분리

### DIFF
--- a/frontend/src/pages/Room/components/Cam/NameBadge.tsx
+++ b/frontend/src/pages/Room/components/Cam/NameBadge.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Mic, MicOff } from "lucide-react";
+import type { NameBadgeProps } from "@/types/cam";
+
+export const NameBadge: React.FC<NameBadgeProps> = ({
+    name,
+    isMuted,
+    onToggleMute,
+}) => {
+    return (
+        <div className="inline-flex items-center gap-1 bg-gray-dark text-white font-light px-3 py-1 rounded-full select-none">
+            <button
+                onClick={onToggleMute}
+                className="flex items-center justify-center w-5 h-5"
+            >
+                {isMuted ? (
+                <MicOff className="text-white w-5 h-5" strokeWidth={1.5}/>
+                ) : (
+                <Mic className="text-white w-5 h-5" strokeWidth={1.5}/>
+                )}
+            </button>
+
+            <span className="text-base">{name}</span>
+        </div>
+    );
+};

--- a/frontend/src/types/cam.ts
+++ b/frontend/src/types/cam.ts
@@ -1,0 +1,5 @@
+export interface NameBadgeProps {
+    name: string;
+    isMuted: boolean;
+    onToggleMute?: () => void;
+}


### PR DESCRIPTION
# 변경점 👍
 EmojiModal.tsx와 NameBadge.tsx에 있던 props를 types/bottomBar.ts와 types/cam.ts로 각각 분리하였습니다.
 
# 비고 ✏
 차현 언니 따라하기 키키 저 잘했죠
