### PR TITLE
docs: 사용자 및 친구 API swagger 명세 작성

### DIFF
--- a/backend/grit/src/main/java/grit/friend/FriendController.java
+++ b/backend/grit/src/main/java/grit/friend/FriendController.java
@@ -1,21 +1,34 @@
 package grit.friend;
 
 import grit.friend.dto.FriendResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Friend", description = "친구 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/friends")
 public class FriendController {
     private final FriendService friendService;
 
-    // 친구 추가
+    @Operation(summary = "친구 추가", description = "특정 사용자를 친구로 추가합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "친구 추가 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (예: 자기 자신을 친구로 추가)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "해당 닉네임을 가진 사용자가 없음", content = @Content),
+            @ApiResponse(responseCode = "409", description = "이미 친구로 등록된 사용자", content = @Content)
+    })
     @PostMapping("/{nickname}")
-    public ResponseEntity<FriendResponseDTO> addFriend(@PathVariable String nickname) {
+    public ResponseEntity<FriendResponseDTO> addFriend(@Parameter(description = "친구의 닉네임", example = "그릿유저친구") @PathVariable String nickname) {
         Long currentUserId = 1L; // 임시 ID
 
         FriendResponseDTO addedFriend = friendService.addFriend(currentUserId, nickname);
@@ -24,8 +37,14 @@ public class FriendController {
     }
 
     // 친구 제거
+    @Operation(summary = "친구 제거", description = "특정 사용자를 친구 목록에서 제거합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "친구 삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (예: 친구 관계가 아님, 자기 자신 삭제 시도)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "해당 닉네임의 친구가 존재하지 않음", content = @Content)
+    })
     @DeleteMapping("/{nickname}")
-    public ResponseEntity<FriendResponseDTO> removeFriend(@PathVariable String nickname) {
+    public ResponseEntity<FriendResponseDTO> removeFriend(@Parameter(description = "친구의 닉네임", example = "그릿유저친구") @PathVariable String nickname) {
         Long currentUserId = 1L; // 임시 ID
 
         FriendResponseDTO removedFriend = friendService.removeFriend(currentUserId, nickname);
@@ -34,8 +53,13 @@ public class FriendController {
     }
 
     // 친구 목록 조회
+    @Operation(summary = "친구 목록 조회", description = "특정 사용자의 친구 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "목록 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자 ID", content = @Content)
+    })
     @GetMapping("/{id}")
-    public ResponseEntity<List<FriendResponseDTO>> findFriends(@PathVariable Long id) {
+    public ResponseEntity<List<FriendResponseDTO>> findFriends(@Parameter(description = "친구 목록을 조회할 사용자의 ID (PK)", example = "1") @PathVariable Long id) {
         return ResponseEntity.ok(friendService.getFriendList(id));
     }
 }

--- a/backend/grit/src/main/java/grit/friend/dto/FriendResponseDTO.java
+++ b/backend/grit/src/main/java/grit/friend/dto/FriendResponseDTO.java
@@ -1,6 +1,7 @@
 package grit.friend.dto;
 
 import grit.user.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,8 +10,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class FriendResponseDTO {
+    @Schema(description = "친구의 사용자 고유 ID (PK)", example = "2")
     private Long friendId;
+
+    @Schema(description = "친구의 닉네임", example = "그릿유저친구")
     private String nickname;
+
+    @Schema(description = "친구의 한 줄 소개", example = "그릿은 정말 좋은 서비스다")
     private String introduction;
 
     public static FriendResponseDTO from(User user) {

--- a/backend/grit/src/main/java/grit/user/UserController.java
+++ b/backend/grit/src/main/java/grit/user/UserController.java
@@ -3,50 +3,78 @@ package grit.user;
 import grit.user.dto.CreateUserRequestDTO;
 import grit.user.dto.UpdateUserRequestDTO;
 import grit.user.dto.UserResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "User", description = "사용자 관련 API")
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
 
-    // 회원 가입
+    @Operation(summary = "회원 가입", description = "신규 사용자를 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "회원가입 성공"),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 이메일 또는 닉네임", content = @Content),
+            @ApiResponse(responseCode = "400", description = "입력값 누락 또는 형식이 올바르지 않음", content = @Content)
+    })
     @PostMapping
     public ResponseEntity<UserResponseDTO> create(@RequestBody CreateUserRequestDTO request) {
         User user = userService.join(request);
-        return ResponseEntity.ok(new UserResponseDTO(user));
+        return ResponseEntity.status(HttpStatus.CREATED).body(new UserResponseDTO(user));
     }
 
-    // 전체 회원 조회
+    @Operation(summary = "전체 회원 조회", description = "전체 사용자를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping
     public ResponseEntity<List<UserResponseDTO>> findAll() {
         return ResponseEntity.ok(userService.findAll());
     }
 
-    // 특정 회원 조회
+    @Operation(summary = "특정 회원 조회", description = "id를 이용하여 특정 사용자를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자 ID", content = @Content)
+    })
     @GetMapping("/{id}")
-    public ResponseEntity<UserResponseDTO> findOne(@PathVariable Long id) {
+    public ResponseEntity<UserResponseDTO> findOne(@Parameter(description = "사용자 고유 ID (PK)", example = "1") @PathVariable Long id) {
         UserResponseDTO response = userService.findOne(id);
         return ResponseEntity.ok(response);
     }
 
-    // 정보 수정
+    @Operation(summary = "정보 수정", description = "사용자의 정보(닉네임, 비밀번호, 한 줄 소개)를 수정합니다. 3개 중 하나만 응답 바디에 적어도 정상적으로 수정됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "정보 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (예: 기존 비밀번호/닉네임과 동일한 값으로 변경 시도)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자 ID", content = @Content),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 닉네임", content = @Content)
+    })
     @PutMapping("/{id}")
-    public ResponseEntity<UserResponseDTO> update(@PathVariable Long id, @RequestBody UpdateUserRequestDTO updateParam) {
+    public ResponseEntity<UserResponseDTO> update(@Parameter(description = "사용자 고유 ID (PK)", example = "1") @PathVariable Long id, @RequestBody UpdateUserRequestDTO updateParam) {
         userService.update(id, updateParam);
 
         UserResponseDTO updateUser = userService.findOne(id);
         return ResponseEntity.ok(updateUser);
     }
 
-    // 회원 탈퇴
+    @Operation(summary = "회원 탈퇴", description = "사용자를 삭제(탈퇴)합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "삭제 성공 (반환값 없음)"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자")
+    })
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
+    public ResponseEntity<Void> delete(@Parameter(description = "사용자 고유 ID (PK)", example = "1") @PathVariable Long id) {
         userService.delete(id);
         return ResponseEntity.noContent().build();
     }

--- a/backend/grit/src/main/java/grit/user/dto/CreateUserRequestDTO.java
+++ b/backend/grit/src/main/java/grit/user/dto/CreateUserRequestDTO.java
@@ -1,14 +1,20 @@
 package grit.user.dto;
 
 import grit.user.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class CreateUserRequestDTO {
+    @Schema(description = "닉네임", example = "그릿유저")
     private String nickname;
+
+    @Schema(description = "비밀번호", example = "grit1234")
     private String password;
+
+    @Schema(description = "이메일", example = "grit1234@a.com")
     private String email;
 
     // DTO를 엔티티로 변환

--- a/backend/grit/src/main/java/grit/user/dto/UpdateUserRequestDTO.java
+++ b/backend/grit/src/main/java/grit/user/dto/UpdateUserRequestDTO.java
@@ -1,12 +1,18 @@
 package grit.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class UpdateUserRequestDTO {
+    @Schema(description = "닉네임", example = "그릿유저")
     private String nickname;
+
+    @Schema(description = "비밀번호", example = "grit1234")
     private String password;
+
+    @Schema(description = "한 줄 소개", example = "오늘 하루도 파이팅")
     private String introduction;
 }

--- a/backend/grit/src/main/java/grit/user/dto/UserResponseDTO.java
+++ b/backend/grit/src/main/java/grit/user/dto/UserResponseDTO.java
@@ -2,6 +2,7 @@ package grit.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import grit.user.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,9 +10,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @JsonPropertyOrder({"id", "nickname", "email", "introduction"})
 public class UserResponseDTO {
+    @Schema(description = "사용자 고유 ID (PK)", example = "1")
     private Long id;
+
+    @Schema(description = "닉네임", example = "그릿유저")
     private String nickname;
+
+    @Schema(description = "이메일", example = "grit1234@a.com")
     private String email;
+
+    @Schema(description = "한 줄 소개", example = "오늘 하루도 파이팅")
     private String introduction;
 
     // User 엔티티 -> DTO 변환


### PR DESCRIPTION
# 변경점 👍
- User, Friend 컨트롤러에 @Operation, @ApiResponse 상세 명세 추가
- DTO 객체에 @Schema 설명 및 예시 값 추가
- 서비스 예외 처리에 맞춘 HTTP 응답 코드(201, 400, 404, 409) 구체화
