### PR TITLE
docs: 그룹 API swagger 명세 작성 및 사용자, 친구 DTO schema에 nullable 속성 명시

### DIFF
--- a/backend/grit/src/main/java/grit/friend/dto/FriendResponseDTO.java
+++ b/backend/grit/src/main/java/grit/friend/dto/FriendResponseDTO.java
@@ -16,7 +16,7 @@ public class FriendResponseDTO {
     @Schema(description = "친구의 닉네임", example = "그릿유저친구")
     private String nickname;
 
-    @Schema(description = "친구의 한 줄 소개", example = "그릿은 정말 좋은 서비스다")
+    @Schema(description = "친구의 한 줄 소개", example = "그릿은 정말 좋은 서비스다", nullable = true)
     private String introduction;
 
     public static FriendResponseDTO from(User user) {

--- a/backend/grit/src/main/java/grit/group/GroupController.java
+++ b/backend/grit/src/main/java/grit/group/GroupController.java
@@ -3,6 +3,12 @@ package grit.group;
 import grit.group.dto.CreateGroupRequestDTO;
 import grit.group.dto.GroupResponseDTO;
 import grit.group.dto.UpdateGroupRequestDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -10,18 +16,22 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Group", description = "그룹 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/groups")
 public class GroupController {
     private final GroupService groupService;
 
-    /**
-     * 1. 그룹 생성
-     * [POST] /api/groups?userId=1
-     */
+    @Operation(summary = "그룹 생성", description = "새로운 그룹을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "그룹 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력값", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자 (생성자 ID 오류)", content = @Content)
+    })
     @PostMapping
     public ResponseEntity<GroupResponseDTO> createGroup(
+            @Parameter(description = "그룹을 생성하는 사용자의 ID", example = "1")
             @RequestParam Long userId, // 테스트용 Id
             @RequestBody CreateGroupRequestDTO request) {
 
@@ -30,11 +40,17 @@ public class GroupController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    // 2. 그룹 가입하기
-    // [POST] /api/groups/{groupId}/join?userId=1
+    @Operation(summary = "그룹 가입", description = "기존에 생성된 그룹에 참여합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "가입 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 그룹 또는 사용자", content = @Content),
+            @ApiResponse(responseCode = "409", description = "이미 가입된 그룹", content = @Content)
+    })
     @PostMapping("/{groupId}/join")
     public ResponseEntity<GroupResponseDTO> joinGroup(
+            @Parameter(description = "가입할 그룹 ID", example = "10")
             @PathVariable Long groupId,
+            @Parameter(description = "가입 신청하는 사용자의 ID", example = "1")
             @RequestParam Long userId) {
 
         groupService.joinGroup(userId, groupId);
@@ -43,30 +59,42 @@ public class GroupController {
         return ResponseEntity.ok(response);
     }
 
-    // 그룹 상세 조회
+    @Operation(summary = "그룹 상세 조회", description = "특정 그룹의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 그룹 ID", content = @Content)
+    })
     @GetMapping("/{groupId}")
-    public ResponseEntity<GroupResponseDTO> getGroup(@PathVariable Long groupId) {
+    public ResponseEntity<GroupResponseDTO> getGroup(
+            @Parameter(description = "조회할 그룹 ID", example = "10")
+            @PathVariable Long groupId) {
+
         GroupResponseDTO response = groupService.getGroup(groupId);
         return ResponseEntity.ok(response);
     }
 
-    /**
-     * 내 그룹 목록 조회
-     * [GET] /api/groups/my?userId=1
-     */
+    @Operation(summary = "내 그룹 목록 조회", description = "내가 속한 모든 그룹 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping("/my")
-    public ResponseEntity<List<GroupResponseDTO>> getMyGroups(@RequestParam Long userId) {
+    public ResponseEntity<List<GroupResponseDTO>> getMyGroups(
+            @Parameter(description = "조회할 사용자의 ID", example = "1")
+            @RequestParam Long userId) {
+
         List<GroupResponseDTO> response = groupService.getMyGroups(userId);
         return ResponseEntity.ok(response);
     }
 
-    /**
-     * 그룹 정보 수정
-     * [PUT] /api/groups/{groupId}?userId=1
-     */
+    @Operation(summary = "그룹 정보 수정", description = "그룹의 정보(이름, 이미지 경로)를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "403", description = "수정 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 그룹 ID", content = @Content)
+    })
     @PutMapping("/{groupId}")
     public ResponseEntity<GroupResponseDTO> updateGroup(
+            @Parameter(description = "수정할 그룹 ID", example = "10")
             @PathVariable Long groupId,
+            @Parameter(description = "요청하는 사용자의 ID", example = "1")
             @RequestParam Long userId,
             @RequestBody UpdateGroupRequestDTO updateRequest) {
 
@@ -76,10 +104,11 @@ public class GroupController {
         return ResponseEntity.ok(response);
     }
 
-    /**
-     * 그룹 나가기 (삭제)
-     * [DELETE] /api/groups/{groupId}?userId=1
-     */
+    @Operation(summary = "그룹 나가기 (삭제)", description = "그룹을 탈퇴합니다. 해당 그룹 멤버의 인원이 0명이 되면 그룹이 자동 삭제됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "탈퇴/삭제 성공 (반환값 없음)"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 그룹 또는 사용자", content = @Content)
+    })
     @DeleteMapping("/{groupId}")
     public ResponseEntity<Void> leaveGroup(
             @PathVariable Long groupId,

--- a/backend/grit/src/main/java/grit/group/dto/CreateGroupRequestDTO.java
+++ b/backend/grit/src/main/java/grit/group/dto/CreateGroupRequestDTO.java
@@ -1,11 +1,15 @@
 package grit.group.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
 public class CreateGroupRequestDTO {
+    @Schema(description = "그룹 이름", example = "그룹 1")
     private String name;
+
+    @Schema(description = "이미지 URL", example = "https://grit-s3.ap-northeast-2.amazonaws.com/profile/default.png", nullable = true)
     private String imageUrl;
 }

--- a/backend/grit/src/main/java/grit/group/dto/GroupResponseDTO.java
+++ b/backend/grit/src/main/java/grit/group/dto/GroupResponseDTO.java
@@ -1,13 +1,21 @@
 package grit.group.dto;
 
 import grit.group.entity.Group;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class GroupResponseDTO {
+    @Schema(description = "그룹 고유 ID (PK)", example = "10")
     private final Long id;
+
+    @Schema(description = "그룹 이름", example = "그룹 1")
     private final String name;
+
+    @Schema(description = "현재 그룹원 수", example = "5")
     private final int memberCount;
+
+    @Schema(description = "이미지 URL", example = "https://grit-s3.ap-northeast-2.amazonaws.com/profile/default.png", nullable = true)
     private final String imageUrl;
 
     // Entity -> DTO 변환

--- a/backend/grit/src/main/java/grit/group/dto/UpdateGroupRequestDTO.java
+++ b/backend/grit/src/main/java/grit/group/dto/UpdateGroupRequestDTO.java
@@ -1,11 +1,15 @@
 package grit.group.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
 public class UpdateGroupRequestDTO {
+    @Schema(description = "그룹 이름", example = "그룹 1")
     private String name;
+
+    @Schema(description = "이미지 URL", example = "https://grit-s3.ap-northeast-2.amazonaws.com/profile/default.png", nullable = true)
     private String imageUrl;
 }

--- a/backend/grit/src/main/java/grit/user/dto/UpdateUserRequestDTO.java
+++ b/backend/grit/src/main/java/grit/user/dto/UpdateUserRequestDTO.java
@@ -13,6 +13,6 @@ public class UpdateUserRequestDTO {
     @Schema(description = "비밀번호", example = "grit1234")
     private String password;
 
-    @Schema(description = "한 줄 소개", example = "오늘 하루도 파이팅")
+    @Schema(description = "한 줄 소개", example = "오늘 하루도 파이팅", nullable = true)
     private String introduction;
 }

--- a/backend/grit/src/main/java/grit/user/dto/UserResponseDTO.java
+++ b/backend/grit/src/main/java/grit/user/dto/UserResponseDTO.java
@@ -19,7 +19,7 @@ public class UserResponseDTO {
     @Schema(description = "이메일", example = "grit1234@a.com")
     private String email;
 
-    @Schema(description = "한 줄 소개", example = "오늘 하루도 파이팅")
+    @Schema(description = "한 줄 소개", example = "오늘 하루도 파이팅", nullable = true)
     private String introduction;
 
     // User 엔티티 -> DTO 변환


### PR DESCRIPTION
# 변경점 👍
- Group 컨트롤러에 @Operation, @ApiResponse 상세 명세 추가
- DTO 객체에 @Schema 설명 및 예시 값 추가
- 서비스 예외 처리에 맞춘 HTTP 응답 코드(201, 400, 404, 409) 구체화
- User, Friend DTO schema에 nullable=true 속성 명시
