### PR TITLE
feat: AccessToken Refresh 절차 구현 및 RefreshToken HttpOnly Cookie에 저장하도록 개선

### DIFF
--- a/backend/grit/src/main/java/grit/domain/auth/controller/AuthController.java
+++ b/backend/grit/src/main/java/grit/domain/auth/controller/AuthController.java
@@ -61,6 +61,7 @@ public class AuthController {
         ResponseCookie cookie = cookieUtils.createEmptyRefreshTokenCookie();
         response.addHeader("Set-Cookie", cookie.toString());
 
+        tokenService.invalidateRefreshToken(cookie.getValue());
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/grit/src/main/java/grit/domain/auth/controller/AuthController.java
+++ b/backend/grit/src/main/java/grit/domain/auth/controller/AuthController.java
@@ -41,7 +41,8 @@ public class AuthController {
         response.addHeader("Set-Cookie", cookie.toString());
 
         return ResponseEntity.status(isMemberPending ? HttpStatus.CREATED : HttpStatus.OK).body(
-                new AuthResponseDto(new MemberResponseDto(member), tokenPair.accessToken(), isMemberPending));
+                new AuthResponseDto(new MemberResponseDto(member), tokenPair.accessToken(),
+                        isMemberPending));
     }
 
     @PostMapping("/refresh")
@@ -57,11 +58,14 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(HttpServletResponse response) {
+    public ResponseEntity<Void> logout(
+            HttpServletResponse response,
+            @CookieValue(value = "refresh_token", required = false) String refreshTokenString
+    ) {
+
         ResponseCookie cookie = cookieUtils.createEmptyRefreshTokenCookie();
         response.addHeader("Set-Cookie", cookie.toString());
-
-        tokenService.invalidateRefreshToken(cookie.getValue());
+        tokenService.invalidateRefreshToken(refreshTokenString);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/grit/src/main/java/grit/domain/auth/controller/AuthController.java
+++ b/backend/grit/src/main/java/grit/domain/auth/controller/AuthController.java
@@ -4,7 +4,6 @@ import grit.domain.auth.TokenPair;
 import grit.domain.auth.dto.AuthResponseDto;
 import grit.domain.auth.dto.GoogleAuthRequestDto;
 import grit.domain.auth.dto.RefreshResponseDto;
-import grit.domain.auth.entity.RefreshToken;
 import grit.domain.auth.service.AuthService;
 import grit.domain.auth.service.TokenService;
 import grit.domain.member.dto.MemberResponseDto;
@@ -53,9 +52,8 @@ public class AuthController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        RefreshToken refreshToken = tokenService.getRefreshToken(refreshTokenString);
         return ResponseEntity.ok(
-                new RefreshResponseDto(tokenService.refreshAccessToken(refreshToken)));
+                new RefreshResponseDto(tokenService.refreshAccessToken(refreshTokenString)));
     }
 
     @PostMapping("/logout")

--- a/backend/grit/src/main/java/grit/domain/auth/controller/AuthController.java
+++ b/backend/grit/src/main/java/grit/domain/auth/controller/AuthController.java
@@ -3,18 +3,21 @@ package grit.domain.auth.controller;
 import grit.domain.auth.TokenPair;
 import grit.domain.auth.dto.AuthResponseDto;
 import grit.domain.auth.dto.GoogleAuthRequestDto;
+import grit.domain.auth.dto.RefreshResponseDto;
+import grit.domain.auth.entity.RefreshToken;
 import grit.domain.auth.service.AuthService;
 import grit.domain.auth.service.TokenService;
 import grit.domain.member.dto.MemberResponseDto;
 import grit.domain.member.entity.Member;
 import grit.domain.member.service.MemberService;
+import grit.global.util.CookieUtils;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -24,16 +27,42 @@ public class AuthController {
     private final AuthService authService;
     private final TokenService tokenService;
     private final MemberService memberService;
+    private final CookieUtils cookieUtils;
 
     @PostMapping("/google")
     public ResponseEntity<AuthResponseDto> googleLogin(
-            @Valid @RequestBody GoogleAuthRequestDto request) {
+            @Valid @RequestBody GoogleAuthRequestDto request,
+            HttpServletResponse response) {
 
         Member member = authService.authenticateWithGoogle(request.code(), request.redirectUri());
         TokenPair tokenPair = tokenService.generateTokens(member);
         boolean isMemberPending = memberService.isMemberPending(member);
 
+        ResponseCookie cookie = cookieUtils.createRefreshTokenCookie(tokenPair.refreshToken());
+        response.addHeader("Set-Cookie", cookie.toString());
+
+        return ResponseEntity.status(isMemberPending ? HttpStatus.CREATED : HttpStatus.OK).body(
+                new AuthResponseDto(new MemberResponseDto(member), tokenPair.accessToken(), isMemberPending));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<RefreshResponseDto> refreshToken(
+            @CookieValue(value = "refresh_token", required = false) String refreshTokenString) {
+
+        if (refreshTokenString == null || refreshTokenString.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        RefreshToken refreshToken = tokenService.getRefreshToken(refreshTokenString);
         return ResponseEntity.ok(
-                new AuthResponseDto(new MemberResponseDto(member), tokenPair, isMemberPending));
+                new RefreshResponseDto(tokenService.refreshAccessToken(refreshToken)));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletResponse response) {
+        ResponseCookie cookie = cookieUtils.createEmptyRefreshTokenCookie();
+        response.addHeader("Set-Cookie", cookie.toString());
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/grit/src/main/java/grit/domain/auth/dto/AuthResponseDto.java
+++ b/backend/grit/src/main/java/grit/domain/auth/dto/AuthResponseDto.java
@@ -1,11 +1,10 @@
 package grit.domain.auth.dto;
 
-import grit.domain.auth.TokenPair;
 import grit.domain.member.dto.MemberResponseDto;
 
 public record AuthResponseDto(
         MemberResponseDto member,
-        TokenPair tokenPair,
+        String accessToken,
         boolean firstTimeUser
 ) {
 

--- a/backend/grit/src/main/java/grit/domain/auth/dto/RefreshResponseDto.java
+++ b/backend/grit/src/main/java/grit/domain/auth/dto/RefreshResponseDto.java
@@ -1,0 +1,5 @@
+package grit.domain.auth.dto;
+
+public record RefreshResponseDto(
+        String accessToken
+) { }

--- a/backend/grit/src/main/java/grit/domain/auth/infrastructure/jwt/AuthenticationFilter.java
+++ b/backend/grit/src/main/java/grit/domain/auth/infrastructure/jwt/AuthenticationFilter.java
@@ -1,6 +1,5 @@
 package grit.domain.auth.infrastructure.jwt;
 
-import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component

--- a/backend/grit/src/main/java/grit/domain/auth/infrastructure/jwt/AuthenticationFilter.java
+++ b/backend/grit/src/main/java/grit/domain/auth/infrastructure/jwt/AuthenticationFilter.java
@@ -1,5 +1,6 @@
 package grit.domain.auth.infrastructure.jwt;
 
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,6 +12,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@Component
 @RequiredArgsConstructor
 public class AuthenticationFilter extends OncePerRequestFilter {
 
@@ -23,11 +25,11 @@ public class AuthenticationFilter extends OncePerRequestFilter {
             @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
         String token = resolveToken(request);
-
         if (token != null) {
             Authentication authentication = jwtProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
+
         filterChain.doFilter(request, response);
     }
 

--- a/backend/grit/src/main/java/grit/domain/auth/infrastructure/jwt/JwtProvider.java
+++ b/backend/grit/src/main/java/grit/domain/auth/infrastructure/jwt/JwtProvider.java
@@ -1,9 +1,6 @@
 package grit.domain.auth.infrastructure.jwt;
 
-import grit.domain.auth.entity.RefreshToken;
-import grit.domain.auth.repository.RefreshTokenRepository;
 import grit.domain.member.entity.Member;
-import grit.global.exception.InvalidCredentialsException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -17,6 +14,7 @@ import java.util.Date;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -34,7 +32,6 @@ public class JwtProvider {
     private Long accessTokenTtl;
 
     private SecretKey secretKey;
-    private final RefreshTokenRepository refreshTokenRepository;
 
     @PostConstruct
     private void init() {
@@ -71,18 +68,7 @@ public class JwtProvider {
                 .compact();
     }
 
-    public Member getMemberFromRefreshToken(String refreshTokenString)
-            throws InvalidCredentialsException {
-        RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenString)
-                .orElseThrow(() -> new InvalidCredentialsException("Invalid refresh token"));
-        if (refreshToken.isExpired()) {
-            throw new InvalidCredentialsException("Refresh token has expired");
-        }
-
-        return refreshToken.getMember();
-    }
-
-    private Claims getClaims(String accessToken) throws InvalidCredentialsException {
+    private Claims getClaims(String accessToken) throws BadCredentialsException {
         try {
             return Jwts.parser()
                     .verifyWith(secretKey)
@@ -90,9 +76,9 @@ public class JwtProvider {
                     .parseSignedClaims(accessToken)
                     .getPayload();
         } catch (ExpiredJwtException e) {
-            throw new InvalidCredentialsException("Expired access token");
+            throw new BadCredentialsException("Expired access token");
         } catch (MalformedJwtException e) {
-            throw new InvalidCredentialsException("Malformed access token");
+            throw new BadCredentialsException("Malformed access token");
         }
     }
 }

--- a/backend/grit/src/main/java/grit/domain/auth/repository/RefreshTokenRepository.java
+++ b/backend/grit/src/main/java/grit/domain/auth/repository/RefreshTokenRepository.java
@@ -1,7 +1,6 @@
 package grit.domain.auth.repository;
 
 import grit.domain.auth.entity.RefreshToken;
-import grit.domain.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,5 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByToken(String token);
-    void deleteByMember(Member member);
+    void deleteByToken(String token);
 }

--- a/backend/grit/src/main/java/grit/domain/auth/service/TokenService.java
+++ b/backend/grit/src/main/java/grit/domain/auth/service/TokenService.java
@@ -39,6 +39,11 @@ public class TokenService {
         return jwtProvider.createAccessToken(refreshToken.getMember());
     }
 
+    @Transactional
+    public void invalidateRefreshToken(String refreshTokenString) {
+        refreshTokenRepository.deleteByToken(refreshTokenString);
+    }
+
     private void checkRefreshTokenValidity(RefreshToken refreshToken) {
         if (refreshToken.isExpired()) {
             refreshTokenRepository.delete(refreshToken);

--- a/backend/grit/src/main/java/grit/domain/auth/service/TokenService.java
+++ b/backend/grit/src/main/java/grit/domain/auth/service/TokenService.java
@@ -42,7 +42,9 @@ public class TokenService {
 
     @Transactional
     public void invalidateRefreshToken(String refreshTokenString) {
-        refreshTokenRepository.deleteByToken(refreshTokenString);
+        if (refreshTokenString != null) {
+            refreshTokenRepository.deleteByToken(refreshTokenString);
+        }
     }
 
     private void checkRefreshTokenValidity(RefreshToken refreshToken) {

--- a/backend/grit/src/main/java/grit/domain/auth/service/TokenService.java
+++ b/backend/grit/src/main/java/grit/domain/auth/service/TokenService.java
@@ -32,17 +32,11 @@ public class TokenService {
     }
 
     @Transactional
-    public String refreshAccessToken(RefreshToken refreshToken) {
-        checkRefreshTokenValidity(refreshToken);
-        return jwtProvider.createAccessToken(refreshToken.getMember());
-    }
-
-    @Transactional
-    public RefreshToken getRefreshToken(String refreshTokenString) {
+    public String refreshAccessToken(String refreshTokenString) {
         RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenString)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid refresh token"));
         checkRefreshTokenValidity(refreshToken);
-        return refreshToken;
+        return jwtProvider.createAccessToken(refreshToken.getMember());
     }
 
     private void checkRefreshTokenValidity(RefreshToken refreshToken) {

--- a/backend/grit/src/main/java/grit/domain/auth/service/TokenService.java
+++ b/backend/grit/src/main/java/grit/domain/auth/service/TokenService.java
@@ -8,6 +8,7 @@ import grit.domain.member.entity.Member;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,7 +35,7 @@ public class TokenService {
     @Transactional
     public String refreshAccessToken(String refreshTokenString) {
         RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenString)
-                .orElseThrow(() -> new IllegalArgumentException("Invalid refresh token"));
+                .orElseThrow(() -> new BadCredentialsException("Invalid refresh token"));
         checkRefreshTokenValidity(refreshToken);
         return jwtProvider.createAccessToken(refreshToken.getMember());
     }
@@ -46,8 +47,7 @@ public class TokenService {
 
     private void checkRefreshTokenValidity(RefreshToken refreshToken) {
         if (refreshToken.isExpired()) {
-            refreshTokenRepository.delete(refreshToken);
-            throw new IllegalArgumentException("Refresh token has expired");
+            throw new BadCredentialsException("Refresh token has expired");
         }
     }
 }

--- a/backend/grit/src/main/java/grit/domain/auth/service/TokenService.java
+++ b/backend/grit/src/main/java/grit/domain/auth/service/TokenService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class TokenService {
+
     @Value("${jwt.refresh-expiration}")
     private Long refreshTokenTtl;
 
@@ -23,11 +24,31 @@ public class TokenService {
     @Transactional
     public TokenPair generateTokens(Member member) {
         String accessToken = jwtProvider.createAccessToken(member);
-        refreshTokenRepository.deleteByMember(member);
 
         RefreshToken refreshToken = RefreshToken.issue(member, Duration.ofMillis(refreshTokenTtl));
         refreshTokenRepository.save(refreshToken);
 
         return new TokenPair(accessToken, refreshToken.getToken());
+    }
+
+    @Transactional
+    public String refreshAccessToken(RefreshToken refreshToken) {
+        checkRefreshTokenValidity(refreshToken);
+        return jwtProvider.createAccessToken(refreshToken.getMember());
+    }
+
+    @Transactional
+    public RefreshToken getRefreshToken(String refreshTokenString) {
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenString)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid refresh token"));
+        checkRefreshTokenValidity(refreshToken);
+        return refreshToken;
+    }
+
+    private void checkRefreshTokenValidity(RefreshToken refreshToken) {
+        if (refreshToken.isExpired()) {
+            refreshTokenRepository.delete(refreshToken);
+            throw new IllegalArgumentException("Refresh token has expired");
+        }
     }
 }

--- a/backend/grit/src/main/java/grit/global/config/SecurityConfig.java
+++ b/backend/grit/src/main/java/grit/global/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package grit.global.config;
 
 import grit.domain.auth.infrastructure.jwt.AuthenticationFilter;
-import grit.domain.auth.infrastructure.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,7 +23,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtProvider jwtProvider;
+    private final AuthenticationFilter authenticationFilter;
 
     // 암호화 도구 등록
     @Bean
@@ -58,8 +57,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .anyRequest().permitAll()
                 )
-                .addFilterBefore(new AuthenticationFilter(jwtProvider),
-                        UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
     }
 }

--- a/backend/grit/src/main/java/grit/global/config/SecurityConfig.java
+++ b/backend/grit/src/main/java/grit/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package grit.global.config;
 
 import grit.domain.auth.infrastructure.jwt.AuthenticationFilter;
+import grit.global.handler.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,6 +25,7 @@ import java.util.List;
 public class SecurityConfig {
 
     private final AuthenticationFilter authenticationFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     // 암호화 도구 등록
     @Bean
@@ -55,7 +57,10 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
+                        .requestMatchers("/api/auth/google").permitAll()
+                )
+                .exceptionHandling(handler -> handler
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
                 )
                 .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/backend/grit/src/main/java/grit/global/exception/GlobalExceptionHandler.java
+++ b/backend/grit/src/main/java/grit/global/exception/GlobalExceptionHandler.java
@@ -15,8 +15,13 @@ import java.util.stream.Collectors;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ErrorResponseDto> handleBadCredentials(BadCredentialsException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponseDto.of(ex.getMessage()));
+    }
+
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ErrorResponseDto> constraintValidationException(ConstraintViolationException ex) {
+    public ResponseEntity<ErrorResponseDto> handleConstraintValidation(ConstraintViolationException ex) {
         String message = ex.getConstraintViolations().stream()
                 .map(ConstraintViolation::getMessage)
                 .collect(Collectors.joining(", "));

--- a/backend/grit/src/main/java/grit/global/exception/GlobalExceptionHandler.java
+++ b/backend/grit/src/main/java/grit/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package grit.global.exception;
+
+import grit.global.exception.dto.ErrorResponseDto;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponseDto> constraintValidationException(ConstraintViolationException ex) {
+        String message = ex.getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .collect(Collectors.joining(", "));
+
+        return ResponseEntity.badRequest().body(ErrorResponseDto.of(message));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponseDto> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+
+        return ResponseEntity.badRequest().body(ErrorResponseDto.of(message));
+    }
+
+}
+

--- a/backend/grit/src/main/java/grit/global/exception/dto/ErrorResponseDto.java
+++ b/backend/grit/src/main/java/grit/global/exception/dto/ErrorResponseDto.java
@@ -1,0 +1,11 @@
+package grit.global.exception.dto;
+
+
+public record ErrorResponseDto(
+        String message
+) {
+    public static ErrorResponseDto of(String message){
+        return new ErrorResponseDto(message);
+    }
+}
+

--- a/backend/grit/src/main/java/grit/global/handler/CustomAuthenticationEntryPoint.java
+++ b/backend/grit/src/main/java/grit/global/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,32 @@
+package grit.global.handler;
+
+import grit.global.exception.dto.ErrorResponseDto;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import java.io.IOException;
+import tools.jackson.databind.json.JsonMapper;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final JsonMapper jsonMapper;
+
+    @Override
+    public void commence(@NonNull HttpServletRequest request, HttpServletResponse response,
+            @NonNull AuthenticationException authException) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json; charset=UTF-8");
+
+        ErrorResponseDto errorResponse = ErrorResponseDto.of("인증 정보가 없습니다.");
+
+        String result = jsonMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(result);
+    }
+}

--- a/backend/grit/src/main/java/grit/global/handler/CustomAuthenticationEntryPoint.java
+++ b/backend/grit/src/main/java/grit/global/handler/CustomAuthenticationEntryPoint.java
@@ -24,7 +24,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json; charset=UTF-8");
 
-        ErrorResponseDto errorResponse = ErrorResponseDto.of("인증 정보가 없습니다.");
+        ErrorResponseDto errorResponse = ErrorResponseDto.of("인증 정보가 없거나 만료되었습니다.");
 
         String result = jsonMapper.writeValueAsString(errorResponse);
         response.getWriter().write(result);

--- a/backend/grit/src/main/java/grit/global/util/CookieUtils.java
+++ b/backend/grit/src/main/java/grit/global/util/CookieUtils.java
@@ -1,0 +1,32 @@
+package grit.global.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtils {
+
+    @Value("${jwt.refresh-expiration}")
+    private Long refreshTokenExpirationMs;
+
+    public ResponseCookie createRefreshTokenCookie(String refreshToken) {
+        return ResponseCookie.from("refresh_token", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(refreshTokenExpirationMs / 1000)
+                .build();
+    }
+
+    public ResponseCookie createEmptyRefreshTokenCookie() {
+        return ResponseCookie.from("refresh_token", "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(0)
+                .build();
+    }
+}


### PR DESCRIPTION
# 변경점 👍
- AccessToken Refresh 절차 구현 및 RefreshToken HttpOnly Cookie에 저장하도록 개선
- SecurityConfig에서 AuthenticationFilter 주입 받도록 변경
