### PR TITLE
feat: 멤버 프로필 최초 설정용 API 및 멤버 닉네임 중복 여부 확인 API 추가

### DIFF
--- a/backend/grit/src/main/java/grit/domain/livekit/api/NewLiveKitController.java
+++ b/backend/grit/src/main/java/grit/domain/livekit/api/NewLiveKitController.java
@@ -44,7 +44,7 @@ public class NewLiveKitController {
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
             @RequestParam Long groupId) {
 
-        Member member = memberService.findOne(memberPrincipal.id());
+        Member member = memberService.findMemberById(memberPrincipal.id());
 
         AccessToken token = new AccessToken(apiKey, apiSecret);
         token.setName(member.getNickname());

--- a/backend/grit/src/main/java/grit/domain/member/controller/MemberController.java
+++ b/backend/grit/src/main/java/grit/domain/member/controller/MemberController.java
@@ -2,7 +2,6 @@ package grit.domain.member.controller;
 
 import grit.domain.auth.infrastructure.jwt.MemberPrincipal;
 import grit.domain.member.dto.MemberNickNameAvailabilityResponseDto;
-import grit.domain.member.dto.MemberNicknameAvailabilityRequestDto;
 import grit.domain.member.dto.MemberProfileInitializeRequestDto;
 import grit.domain.member.entity.Member;
 import grit.domain.member.service.MemberService;
@@ -69,10 +68,10 @@ public class MemberController {
     @GetMapping("/nickname-availability")
     public ResponseEntity<MemberNickNameAvailabilityResponseDto> checkNicknameAvailability(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
-            @RequestParam MemberNicknameAvailabilityRequestDto requestDto) {
+            @RequestParam("nickname") String nickname) {
 
         Member member = memberService.findMemberById(memberPrincipal.id());
-        boolean isAvailable = !memberService.isNicknameTaken(member, requestDto.nickname());
+        boolean isAvailable = !memberService.isNicknameTaken(member, nickname);
         return ResponseEntity.status(isAvailable ? HttpStatus.OK : HttpStatus.CONFLICT)
                 .body(new MemberNickNameAvailabilityResponseDto(isAvailable));
     }

--- a/backend/grit/src/main/java/grit/domain/member/controller/MemberController.java
+++ b/backend/grit/src/main/java/grit/domain/member/controller/MemberController.java
@@ -1,9 +1,12 @@
 package grit.domain.member.controller;
 
 import grit.domain.auth.infrastructure.jwt.MemberPrincipal;
+import grit.domain.member.dto.MemberNickNameAvailabilityResponseDto;
+import grit.domain.member.dto.MemberNicknameAvailabilityRequestDto;
+import grit.domain.member.dto.MemberProfileInitializeRequestDto;
 import grit.domain.member.entity.Member;
 import grit.domain.member.service.MemberService;
-import grit.domain.member.dto.MemberUpdateRequestDto;
+import grit.domain.member.dto.MemberProfilePatchRequestDto;
 import grit.domain.member.dto.MemberResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -11,11 +14,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Tag(name = "User", description = "사용자 관련 API")
 @RestController
@@ -25,25 +27,6 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    /*@Operation(summary = "회원 가입", description = "신규 사용자를 등록합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "회원가입 성공"),
-            @ApiResponse(responseCode = "409", description = "이미 존재하는 이메일 또는 닉네임", content = @Content),
-            @ApiResponse(responseCode = "400", description = "입력값 누락 또는 형식이 올바르지 않음", content = @Content)
-    })
-    @PostMapping
-    public ResponseEntity<MemberResponseDto> create(@RequestBody MemberCreateRequestDto request) {
-        //Member member = memberService.join(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(null);
-    }*/
-
-    @Operation(summary = "전체 회원 조회", description = "전체 사용자를 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "조회 성공")
-    @GetMapping
-    public ResponseEntity<List<MemberResponseDto>> findAll() {
-        return ResponseEntity.ok(memberService.findAll());
-    }
-
     @Operation(summary = "특정 회원 조회", description = "id를 이용하여 특정 사용자를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
@@ -52,7 +35,7 @@ public class MemberController {
     @GetMapping("/{id}")
     public ResponseEntity<MemberResponseDto> findOne(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
-        Member member = memberService.findOne(memberPrincipal.id());
+        Member member = memberService.findMemberById(memberPrincipal.id());
         return ResponseEntity.ok(new MemberResponseDto(member));
     }
 
@@ -63,14 +46,35 @@ public class MemberController {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자 ID", content = @Content),
             @ApiResponse(responseCode = "409", description = "이미 사용 중인 닉네임", content = @Content)
     })
-    @PutMapping("/{id}")
-    public ResponseEntity<MemberResponseDto> update(
+    @PatchMapping("/me/profile")
+    public ResponseEntity<MemberResponseDto> patchProfile(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
-            @RequestBody MemberUpdateRequestDto updateParam) {
-        memberService.update(memberPrincipal.id(), updateParam);
+            @RequestBody MemberProfilePatchRequestDto requestDto) {
 
-        Member updatedMember = memberService.findOne(memberPrincipal.id());
-        return ResponseEntity.ok(new MemberResponseDto(updatedMember));
+        Member member = memberService.findMemberById(memberPrincipal.id());
+        memberService.updateProfile(member, requestDto.getNickname(), requestDto.getIntroduction(), requestDto.getImage());
+        return ResponseEntity.ok(new MemberResponseDto(member));
+    }
+
+    @PostMapping("/me/profile")
+    public ResponseEntity<MemberResponseDto> initializeProfile(
+            @AuthenticationPrincipal MemberPrincipal memberPrincipal,
+            @RequestBody MemberProfileInitializeRequestDto requestDto) {
+
+        Member member = memberService.findMemberById(memberPrincipal.id());
+        memberService.initializeProfile(member, requestDto.nickname(), requestDto.introduction(), requestDto.image());
+        return ResponseEntity.ok(new MemberResponseDto(member));
+    }
+
+    @GetMapping("/nickname-availability")
+    public ResponseEntity<MemberNickNameAvailabilityResponseDto> checkNicknameAvailability(
+            @AuthenticationPrincipal MemberPrincipal memberPrincipal,
+            @RequestParam MemberNicknameAvailabilityRequestDto requestDto) {
+
+        Member member = memberService.findMemberById(memberPrincipal.id());
+        boolean isAvailable = !memberService.isNicknameTaken(member, requestDto.nickname());
+        return ResponseEntity.status(isAvailable ? HttpStatus.OK : HttpStatus.CONFLICT)
+                .body(new MemberNickNameAvailabilityResponseDto(isAvailable));
     }
 
     @Operation(summary = "회원 탈퇴", description = "사용자를 삭제(탈퇴)합니다.")
@@ -78,10 +82,12 @@ public class MemberController {
             @ApiResponse(responseCode = "204", description = "삭제 성공 (반환값 없음)"),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자")
     })
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/me")
     public ResponseEntity<Void> delete(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
-        memberService.delete(memberPrincipal.id());
+
+        Member member = memberService.findMemberById(memberPrincipal.id());
+        memberService.delete(member);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/grit/src/main/java/grit/domain/member/controller/MemberController.java
+++ b/backend/grit/src/main/java/grit/domain/member/controller/MemberController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -48,7 +49,7 @@ public class MemberController {
     @PatchMapping("/me/profile")
     public ResponseEntity<MemberResponseDto> patchProfile(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
-            @RequestBody MemberProfilePatchRequestDto requestDto) {
+            @Valid @RequestBody MemberProfilePatchRequestDto requestDto) {
 
         Member member = memberService.findMemberById(memberPrincipal.id());
         memberService.updateProfile(member, requestDto.getNickname(), requestDto.getIntroduction(), requestDto.getImage());
@@ -58,7 +59,7 @@ public class MemberController {
     @PostMapping("/me/profile")
     public ResponseEntity<MemberResponseDto> initializeProfile(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
-            @RequestBody MemberProfileInitializeRequestDto requestDto) {
+            @Valid @RequestBody MemberProfileInitializeRequestDto requestDto) {
 
         Member member = memberService.findMemberById(memberPrincipal.id());
         memberService.initializeProfile(member, requestDto.nickname(), requestDto.introduction(), requestDto.image());

--- a/backend/grit/src/main/java/grit/domain/member/dto/MemberNickNameAvailabilityResponseDto.java
+++ b/backend/grit/src/main/java/grit/domain/member/dto/MemberNickNameAvailabilityResponseDto.java
@@ -1,0 +1,7 @@
+package grit.domain.member.dto;
+
+public record MemberNickNameAvailabilityResponseDto(
+        Boolean isAvailable
+) {
+
+}

--- a/backend/grit/src/main/java/grit/domain/member/dto/MemberNicknameAvailabilityRequestDto.java
+++ b/backend/grit/src/main/java/grit/domain/member/dto/MemberNicknameAvailabilityRequestDto.java
@@ -1,7 +1,0 @@
-package grit.domain.member.dto;
-
-public record MemberNicknameAvailabilityRequestDto (
-        String nickname
-){
-
-}

--- a/backend/grit/src/main/java/grit/domain/member/dto/MemberNicknameAvailabilityRequestDto.java
+++ b/backend/grit/src/main/java/grit/domain/member/dto/MemberNicknameAvailabilityRequestDto.java
@@ -1,0 +1,7 @@
+package grit.domain.member.dto;
+
+public record MemberNicknameAvailabilityRequestDto (
+        String nickname
+){
+
+}

--- a/backend/grit/src/main/java/grit/domain/member/dto/MemberProfileInitializeRequestDto.java
+++ b/backend/grit/src/main/java/grit/domain/member/dto/MemberProfileInitializeRequestDto.java
@@ -9,11 +9,7 @@ public record MemberProfileInitializeRequestDto(
         @NotNull @NotBlank
         String nickname,
 
-        @Schema(description = "비밀번호", example = "grit1234")
-        @NotNull @NotBlank
-        String password,
-
-        @Schema(description = "한 줄 소개", example = "오늘 하루도 파이팅", nullable = true)
+        @Schema(description = "한 줄 소개", example = "오늘 하루도 파이팅")
         @NotNull @NotBlank
         String introduction,
 

--- a/backend/grit/src/main/java/grit/domain/member/dto/MemberProfileInitializeRequestDto.java
+++ b/backend/grit/src/main/java/grit/domain/member/dto/MemberProfileInitializeRequestDto.java
@@ -1,0 +1,24 @@
+package grit.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record MemberProfileInitializeRequestDto(
+        @Schema(description = "닉네임", example = "그릿유저")
+        @NotNull @NotBlank
+        String nickname,
+
+        @Schema(description = "비밀번호", example = "grit1234")
+        @NotNull @NotBlank
+        String password,
+
+        @Schema(description = "한 줄 소개", example = "오늘 하루도 파이팅", nullable = true)
+        @NotNull @NotBlank
+        String introduction,
+
+        @NotBlank
+        String image
+) {
+
+}

--- a/backend/grit/src/main/java/grit/domain/member/dto/MemberProfileInitializeRequestDto.java
+++ b/backend/grit/src/main/java/grit/domain/member/dto/MemberProfileInitializeRequestDto.java
@@ -2,15 +2,14 @@ package grit.domain.member.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 public record MemberProfileInitializeRequestDto(
         @Schema(description = "닉네임", example = "그릿유저")
-        @NotNull @NotBlank
+        @NotBlank
         String nickname,
 
         @Schema(description = "한 줄 소개", example = "오늘 하루도 파이팅")
-        @NotNull @NotBlank
+        @NotBlank
         String introduction,
 
         @NotBlank

--- a/backend/grit/src/main/java/grit/domain/member/dto/MemberProfilePatchRequestDto.java
+++ b/backend/grit/src/main/java/grit/domain/member/dto/MemberProfilePatchRequestDto.java
@@ -1,18 +1,25 @@
 package grit.domain.member.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-public class MemberUpdateRequestDto {
+public class MemberProfilePatchRequestDto {
     @Schema(description = "닉네임", example = "그릿유저")
+    @NotBlank
     private String nickname;
 
     @Schema(description = "비밀번호", example = "grit1234")
+    @NotBlank
     private String password;
 
     @Schema(description = "한 줄 소개", example = "오늘 하루도 파이팅", nullable = true)
+    @NotBlank
     private String introduction;
+
+    @NotBlank
+    private String image;
 }

--- a/backend/grit/src/main/java/grit/domain/member/dto/MemberProfilePatchRequestDto.java
+++ b/backend/grit/src/main/java/grit/domain/member/dto/MemberProfilePatchRequestDto.java
@@ -1,7 +1,6 @@
 package grit.domain.member.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,13 +8,10 @@ import lombok.Setter;
 @Setter
 public class MemberProfilePatchRequestDto {
     @Schema(description = "닉네임", example = "그릿유저")
-    @NotBlank
     private String nickname;
 
     @Schema(description = "한 줄 소개", example = "오늘 하루도 파이팅", nullable = true)
-    @NotBlank
     private String introduction;
 
-    @NotBlank
     private String image;
 }

--- a/backend/grit/src/main/java/grit/domain/member/dto/MemberProfilePatchRequestDto.java
+++ b/backend/grit/src/main/java/grit/domain/member/dto/MemberProfilePatchRequestDto.java
@@ -12,10 +12,6 @@ public class MemberProfilePatchRequestDto {
     @NotBlank
     private String nickname;
 
-    @Schema(description = "비밀번호", example = "grit1234")
-    @NotBlank
-    private String password;
-
     @Schema(description = "한 줄 소개", example = "오늘 하루도 파이팅", nullable = true)
     @NotBlank
     private String introduction;

--- a/backend/grit/src/main/java/grit/domain/member/entity/Member.java
+++ b/backend/grit/src/main/java/grit/domain/member/entity/Member.java
@@ -38,15 +38,12 @@ public class Member {
     @Column(nullable = false)
     private String providerId;
 
-    @Setter
     @Column(length = 40)
     private String introduction;
 
-    @Setter
     private String image;
 
     @Builder.Default
-    @Setter
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role = Role.PENDING;

--- a/backend/grit/src/main/java/grit/domain/member/entity/Member.java
+++ b/backend/grit/src/main/java/grit/domain/member/entity/Member.java
@@ -90,6 +90,8 @@ public class Member {
     }
 
     public void updateProfile(String nickname, String introduction, String image) {
+        validateRoleForUpdate();
+
         updateIfPresent(nickname, val -> this.nickname = val, "닉네임");
         updateIfPresent(introduction, val -> this.introduction = val, "자기소개");
         updateIfPresent(image, val -> this.image = val, "이미지");
@@ -99,6 +101,12 @@ public class Member {
     private void validateRoleForInitialization() {
         if (this.role != Role.PENDING) {
             throw new ProfileAlreadyInitializedException("이미 프로필이 초기화된 회원입니다.");
+        }
+    }
+
+    private void validateRoleForUpdate() {
+        if (this.role == Role.PENDING) {
+            throw new ProfileAlreadyInitializedException("아직 프로필이 초기화되지 않은 회원입니다.");
         }
     }
 

--- a/backend/grit/src/main/java/grit/domain/member/entity/Member.java
+++ b/backend/grit/src/main/java/grit/domain/member/entity/Member.java
@@ -2,11 +2,13 @@ package grit.domain.member.entity;
 
 import grit.domain.member.constant.Role;
 import grit.domain.member.constant.SocialProvider;
+import grit.global.exception.ProfileAlreadyInitializedException;
 import java.time.LocalDateTime;
 import java.util.*;
 
 import grit.domain.group.entity.MemberGroup;
 import jakarta.persistence.*;
+import java.util.function.Consumer;
 import lombok.*;
 
 @Getter
@@ -17,6 +19,7 @@ import lombok.*;
 @Table(name = "members")
 @ToString(exclude = {"memberGroups", "friends"}) // lombok 무한루프 방지용
 public class Member {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -43,9 +46,10 @@ public class Member {
     private String image;
 
     @Builder.Default
+    @Setter
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Role role = Role.USER;
+    private Role role = Role.PENDING;
 
     @org.hibernate.annotations.CreationTimestamp
     @Column(nullable = false, updatable = false)
@@ -59,9 +63,9 @@ public class Member {
     // friend
     @ManyToMany
     @JoinTable(
-        name = "friendship",
-        joinColumns = @JoinColumn(name = "member_id"),
-        inverseJoinColumns = @JoinColumn(name = "friend_id")
+            name = "friendship",
+            joinColumns = @JoinColumn(name = "member_id"),
+            inverseJoinColumns = @JoinColumn(name = "friend_id")
     )
     @Builder.Default
     private Set<Member> friends = new HashSet<>();
@@ -75,4 +79,40 @@ public class Member {
         this.friends.remove(member);
         member.getFriends().remove(this);
     }
+
+    public void initializeProfile(String nickname, String introduction, String image) {
+        validateRoleForInitialization();
+
+        this.nickname = validateAndGet(nickname, "닉네임");
+        this.introduction = validateAndGet(introduction, "자기소개");
+        this.image = validateAndGet(image, "이미지");
+        this.role = Role.USER;
+    }
+
+    public void updateProfile(String nickname, String introduction, String image) {
+        updateIfPresent(nickname, val -> this.nickname = val, "닉네임");
+        updateIfPresent(introduction, val -> this.introduction = val, "자기소개");
+        updateIfPresent(image, val -> this.image = val, "이미지");
+    }
+
+
+    private void validateRoleForInitialization() {
+        if (this.role != Role.PENDING) {
+            throw new ProfileAlreadyInitializedException("이미 프로필이 초기화된 회원입니다.");
+        }
+    }
+
+    private String validateAndGet(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + "은(는) 필수이며 공백일 수 없습니다.");
+        }
+        return value;
+    }
+
+    private void updateIfPresent(String value, Consumer<String> setter, String fieldName) {
+        if (value != null) {
+            setter.accept(validateAndGet(value, fieldName));
+        }
+    }
+
 }

--- a/backend/grit/src/main/java/grit/domain/member/service/MemberService.java
+++ b/backend/grit/src/main/java/grit/domain/member/service/MemberService.java
@@ -33,7 +33,7 @@ public class MemberService {
 
     public boolean isNicknameTaken(Member currentMember, String nickname) {
         if (nickname.equals(currentMember.getNickname())) {
-            return true;
+            return false;
         }
 
         return memberRepository.existsByNickname(nickname);
@@ -58,19 +58,18 @@ public class MemberService {
     public void initializeProfile(
             Member member, String nickname, String introduction, String image) {
 
-        if (isNicknameTaken(member, nickname)) {
+        if (nickname != null && isNicknameTaken(member, nickname)) {
             throw new IllegalStateException("이미 사용 중인 닉네임입니다.");
         }
         member.initializeProfile(nickname, introduction, image);
     }
-
 
     // 정보 수정
     @Transactional
     public void updateProfile(
             Member member, String nickname, String introduction, String image) {
 
-        if (isNicknameTaken(member, nickname)) {
+        if (nickname != null && isNicknameTaken(member, nickname)) {
             throw new IllegalStateException("이미 사용 중인 닉네임입니다.");
         }
         member.updateProfile(nickname, introduction, image);

--- a/backend/grit/src/main/java/grit/domain/member/service/MemberService.java
+++ b/backend/grit/src/main/java/grit/domain/member/service/MemberService.java
@@ -32,10 +32,6 @@ public class MemberService {
     }
 
     public boolean isNicknameTaken(Member currentMember, String nickname) {
-        if (nickname == null || nickname.isEmpty()) {
-            return true;
-        }
-
         if (nickname.equals(currentMember.getNickname())) {
             return false;
         }

--- a/backend/grit/src/main/java/grit/domain/member/service/MemberService.java
+++ b/backend/grit/src/main/java/grit/domain/member/service/MemberService.java
@@ -32,6 +32,10 @@ public class MemberService {
     }
 
     public boolean isNicknameTaken(Member currentMember, String nickname) {
+        if (nickname == null || nickname.isEmpty()) {
+            return true;
+        }
+
         if (nickname.equals(currentMember.getNickname())) {
             return false;
         }
@@ -58,7 +62,7 @@ public class MemberService {
     public void initializeProfile(
             Member member, String nickname, String introduction, String image) {
 
-        if (nickname != null && isNicknameTaken(member, nickname)) {
+        if (isNicknameTaken(member, nickname)) {
             throw new IllegalStateException("이미 사용 중인 닉네임입니다.");
         }
         member.initializeProfile(nickname, introduction, image);

--- a/backend/grit/src/main/java/grit/domain/member/service/MemberService.java
+++ b/backend/grit/src/main/java/grit/domain/member/service/MemberService.java
@@ -2,22 +2,19 @@ package grit.domain.member.service;
 
 import grit.domain.member.constant.Role;
 import grit.domain.member.constant.SocialProvider;
-import grit.domain.member.dto.MemberUpdateRequestDto;
-import grit.domain.member.dto.MemberResponseDto;
 import grit.domain.member.entity.Member;
 import grit.domain.member.repository.MemberRepository;
+import grit.global.exception.EntityNotFoundException;
 import java.util.Optional;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.NoSuchElementException;
-
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class MemberService {
+
     private final MemberRepository memberRepository;
 
     // 회원 가입
@@ -34,11 +31,12 @@ public class MemberService {
         return memberRepository.save(member);
     }
 
-    // 닉네임 중복 체크
-    private void validNickname(String nickname) {
-        if (memberRepository.existsByNickname(nickname)) {
-            throw new IllegalStateException("이미 존재하는 닉네임입니다.");
+    public boolean isNicknameTaken(Member currentMember, String nickname) {
+        if (nickname.equals(currentMember.getNickname())) {
+            return true;
         }
+
+        return memberRepository.existsByNickname(nickname);
     }
 
     // 이메일 중복 체크
@@ -50,58 +48,36 @@ public class MemberService {
         }
     }
 
-    // 회원 전체 조회
-    public List<MemberResponseDto> findAll() {
-        return memberRepository.findAll().stream()
-                .map(MemberResponseDto::new)
-                .toList();
+    // 단일 회원 조회
+    public Member findMemberById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
     }
 
-    // 단일 회원 조회
-    public Member findOne(Long id) {
-        return memberRepository.findById(id)
-                .orElseThrow(() -> new NoSuchElementException(id + " 회원을 찾을 수 없습니다."));
+    @Transactional
+    public void initializeProfile(
+            Member member, String nickname, String introduction, String image) {
+
+        if (isNicknameTaken(member, nickname)) {
+            throw new IllegalStateException("이미 사용 중인 닉네임입니다.");
+        }
+        member.initializeProfile(nickname, introduction, image);
     }
+
 
     // 정보 수정
     @Transactional
-    public void update(Long id, MemberUpdateRequestDto updateParam) {
-        Member member = findMemberById(id);
+    public void updateProfile(
+            Member member, String nickname, String introduction, String image) {
 
-        updateNickname(member, updateParam.getNickname());
-        updateIntroduction(member, updateParam.getIntroduction());
-    }
-
-    // 사용자 조회 로직
-    private Member findMemberById(Long id) {
-        return memberRepository.findById(id)
-                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));
-    }
-
-    // 닉네임 수정
-    private void updateNickname(Member member, String newNickname) {
-        if (newNickname == null) return;
-
-        if (newNickname.equals(member.getNickname()))
-            throw new IllegalStateException("변경하려는 닉네임이 기존 닉네임과 동일합니다.");
-
-        if (memberRepository.existsByNickname(newNickname))
+        if (isNicknameTaken(member, nickname)) {
             throw new IllegalStateException("이미 사용 중인 닉네임입니다.");
-
-        member.setNickname(newNickname);
-    }
-
-    // 한 줄 소개 수정
-    private void updateIntroduction(Member member, String newIntroduction) {
-        if (newIntroduction != null) {
-            member.setIntroduction(newIntroduction);
         }
+        member.updateProfile(nickname, introduction, image);
     }
 
     // 회원 탈퇴
-    public void delete(Long id) {
-        Member member = memberRepository.findById(id)
-                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));
+    public void delete(Member member) {
         memberRepository.delete(member);
     }
 

--- a/backend/grit/src/main/java/grit/global/exception/EntityNotFoundException.java
+++ b/backend/grit/src/main/java/grit/global/exception/EntityNotFoundException.java
@@ -1,0 +1,8 @@
+package grit.global.exception;
+
+public class EntityNotFoundException extends RuntimeException {
+
+    public EntityNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/grit/src/main/java/grit/global/exception/GlobalExceptionHandler.java
+++ b/backend/grit/src/main/java/grit/global/exception/GlobalExceptionHandler.java
@@ -20,6 +20,11 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponseDto.of(ex.getMessage()));
     }
 
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponseDto> handleEntityNotFound(EntityNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponseDto.of(ex.getMessage()));
+    }
+
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ErrorResponseDto> handleConstraintValidation(ConstraintViolationException ex) {
         String message = ex.getConstraintViolations().stream()

--- a/backend/grit/src/main/java/grit/global/exception/GlobalExceptionHandler.java
+++ b/backend/grit/src/main/java/grit/global/exception/GlobalExceptionHandler.java
@@ -25,6 +25,11 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponseDto.of(ex.getMessage()));
     }
 
+    @ExceptionHandler(ProfileAlreadyInitializedException.class)
+    public ResponseEntity<ErrorResponseDto> handleEntityNotFound(ProfileAlreadyInitializedException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ErrorResponseDto.of(ex.getMessage()));
+    }
+
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ErrorResponseDto> handleConstraintValidation(ConstraintViolationException ex) {
         String message = ex.getConstraintViolations().stream()

--- a/backend/grit/src/main/java/grit/global/exception/ProfileAlreadyInitializedException.java
+++ b/backend/grit/src/main/java/grit/global/exception/ProfileAlreadyInitializedException.java
@@ -1,0 +1,8 @@
+package grit.global.exception;
+
+public class ProfileAlreadyInitializedException extends RuntimeException {
+
+    public ProfileAlreadyInitializedException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
# 변경점 👍
멤버 프로필 최초 설정용 API 및 멤버 닉네임 중복 여부 확인 API 추가
`POST /api/members/me/profile`
`PATCH /api/members/me/profile`
`GET /api/members/nickname-availability?nickname={닉네임}`

