### PR TITLE
refactor: api endpoints 및 dto 구조 변경

### DIFF
--- a/frontend/src/apis/client/apiClient.ts
+++ b/frontend/src/apis/client/apiClient.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { API_BASE_URL } from "@/apis/constants/endpoints";
 import { PATHS } from "@/routes/path";
-import { AUTH_REFRESH_ENDPOINT } from "@/apis/constants/endpoints";
+import { API_ENDPOINTS } from "@/apis/constants/endpoints";
 
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,
@@ -54,7 +54,7 @@ apiClient.interceptors.response.use(
     if (
       error.response?.status === 401 &&
       !originalRequest._retry &&
-      originalRequest.url !== AUTH_REFRESH_ENDPOINT
+      originalRequest.url !== API_ENDPOINTS.AUTH.REFRESH
     ) {
       if (isRefreshingToken) {
         return new Promise((resolve) => {
@@ -70,7 +70,7 @@ apiClient.interceptors.response.use(
 
       try {
         const refreshResponse = await axios.post(
-          `${API_BASE_URL}${AUTH_REFRESH_ENDPOINT}`,
+          `${API_BASE_URL}${API_ENDPOINTS.AUTH.REFRESH}`,
           {},
           { withCredentials: true },
         );

--- a/frontend/src/apis/constants/endpoints.ts
+++ b/frontend/src/apis/constants/endpoints.ts
@@ -1,10 +1,18 @@
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 export const LIVEKIT_URL = import.meta.env.VITE_LIVEKIT_URL;
 
-export const LIVEKIT_TOKEN_ENDPOINT = "/livekit/token";
-
-export const AUTH_GOOGLE_ENDPOINT = "/api/auth/google";
-export const AUTH_REFRESH_ENDPOINT = "/api/auth/refresh";
-export const AUTH_LOGOUT_ENDPOINT = "/api/auth/logout";
-
-export const GROUPS_ENDPOINT = "/api/groups";
+export const API_ENDPOINTS = {
+  AUTH: {
+    GOOGLE: "/api/auth/google",
+    REFRESH: "/api/auth/refresh",
+    LOGOUT: "/api/auth/logout",
+  },
+  GROUP: {
+    BASE: "/api/groups",
+    DETAIL: (id: number) => `/api/groups/${id}`,
+  },
+  LIVEKIT: {
+    URL: import.meta.env.VITE_LIVEKIT_URL,
+    TOKEN: "/livekit/token",
+  },
+} as const;

--- a/frontend/src/apis/services/auth.ts
+++ b/frontend/src/apis/services/auth.ts
@@ -6,9 +6,7 @@ import type {
   Member,
 } from "@/apis/types/auth";
 import { OAUTH_CONFIG } from "@/apis/constants/oauth";
-import { AUTH_GOOGLE_ENDPOINT } from "@/apis/constants/endpoints";
-import { AUTH_REFRESH_ENDPOINT } from "@/apis/constants/endpoints";
-import { AUTH_LOGOUT_ENDPOINT } from "@/apis/constants/endpoints";
+import { API_ENDPOINTS } from "@/apis/constants/endpoints";
 import type { RefreshTokenResponse } from "@/apis/types/auth";
 
 //구글에서 받은 code를 백엔드로 전송
@@ -23,7 +21,7 @@ export const loginGoogle = async (
   };
 
   const response = await apiClient.post<GoogleLoginResponse>(
-    AUTH_GOOGLE_ENDPOINT,
+    API_ENDPOINTS.AUTH.GOOGLE,
     requestBody,
     { withCredentials: true },
   );
@@ -50,7 +48,7 @@ export const loginGoogle = async (
 //리프레시 토큰
 export const refreshAccessToken = async (): Promise<string> => {
   const response = await apiClient.post<RefreshTokenResponse>(
-    AUTH_REFRESH_ENDPOINT,
+    API_ENDPOINTS.AUTH.REFRESH,
     {},
     { withCredentials: true },
   );
@@ -83,7 +81,7 @@ export const getCurrentUser = (): Member | null => {
 export const logout = async (): Promise<void> => {
   try {
     await apiClient.post(
-      AUTH_LOGOUT_ENDPOINT,
+      API_ENDPOINTS.AUTH.LOGOUT,
       {},
       {
         withCredentials: true,

--- a/frontend/src/apis/services/group.ts
+++ b/frontend/src/apis/services/group.ts
@@ -1,39 +1,25 @@
 import apiClient from "@/apis/client/apiClient";
-import { GROUPS_ENDPOINT } from "@/apis/constants/endpoints";
+import { API_ENDPOINTS } from "@/apis/constants/endpoints";
 import type {
   CreateGroupRequest,
-  CreateGroupResponse,
   UpdateGroupRequest,
-  UpdateGroupResponse,
-} from "@/apis/types/group";
+  Group,
+} from "@/apis/types";
 
-// 그룹 생성
-export const createGroup = async (
-  userId: number,
-  data: CreateGroupRequest
-): Promise<CreateGroupResponse> => {
-  const response = await apiClient.post<CreateGroupResponse>(
-    GROUPS_ENDPOINT,
-    data,
-    {
-      params: { userId },
-    }
-  );
-  return response.data;
-};
+export const groupApi = {
+  create: async (data: CreateGroupRequest): Promise<Group> => {
+    const response = await apiClient.post<Group>(
+      API_ENDPOINTS.GROUP.BASE,
+      data,
+    );
+    return response.data;
+  },
 
-//그룹 정보 수정
-export const updateGroup = async (
-  groupId: number,
-  userId: number,
-  data: UpdateGroupRequest
-): Promise<UpdateGroupResponse> => {
-  const response = await apiClient.put<UpdateGroupResponse>(
-    `${GROUPS_ENDPOINT}/${groupId}`,
-    data,
-    {
-      params: { userId },
-    }
-  );
-  return response.data;
-};
+  update: async (groupId: number, data: UpdateGroupRequest): Promise<Group> => {
+    const response = await apiClient.put<Group>(
+      API_ENDPOINTS.GROUP.DETAIL(groupId),
+      data,
+    );
+    return response.data;
+  },
+} as const;

--- a/frontend/src/apis/services/livekit.ts
+++ b/frontend/src/apis/services/livekit.ts
@@ -1,13 +1,16 @@
 import apiClient from "@/apis/client/apiClient";
 import type { TokenResponse } from "@/apis/types/livekit";
-import { LIVEKIT_TOKEN_ENDPOINT } from "@/apis/constants/endpoints";
+import { API_ENDPOINTS } from "@/apis/constants/endpoints";
 
 export const getLiveKitToken = async (
   room: string,
-  user: string
+  user: string,
 ): Promise<string> => {
-  const response = await apiClient.get<TokenResponse>(LIVEKIT_TOKEN_ENDPOINT, {
-    params: { room, user },
-  });
+  const response = await apiClient.get<TokenResponse>(
+    API_ENDPOINTS.LIVEKIT.TOKEN,
+    {
+      params: { room, user },
+    },
+  );
   return response.data.token;
 };

--- a/frontend/src/apis/types/group.ts
+++ b/frontend/src/apis/types/group.ts
@@ -1,28 +1,22 @@
-// 그룹 생성 요청
-export interface CreateGroupRequest {
+export interface GroupCoreInfo {
+  id: number;
   name: string;
+  memberCount: number;
   imageUrl: string;
 }
 
-// 그룹 생성 응답
-export interface CreateGroupResponse {
-  id: number;
-  name: string;
+export interface Group extends GroupCoreInfo {
   inviteCode: string;
-  memberCount: number;
-  imageUrl: string;
 }
 
-//그룹 정보 수정 요청
-export interface UpdateGroupRequest {
+export interface GroupInput {
   name: string;
   imageUrl: string;
 }
 
-//그룹 정보 수정 응답
-export interface UpdateGroupResponse {
-  id: number;
-  name: string;
-  memberCount: number;
-  imageUrl: string;
+export interface GroupList {
+  groups: Group[];
 }
+
+export type CreateGroupRequest = GroupInput;
+export type UpdateGroupRequest = Partial<GroupInput>;

--- a/frontend/src/apis/types/index.ts
+++ b/frontend/src/apis/types/index.ts
@@ -1,0 +1,1 @@
+export * from "@/apis/types/group";

--- a/frontend/src/pages/Home/components/Modals/CreateGroupModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/CreateGroupModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Copy } from "lucide-react";
 import Modal from "@/components/Modal";
-import { createGroup } from "@/apis/services/group";
+import { groupApi } from "@/apis/services/group";
 import { ImageUploader } from "@/components/ImageUploader";
 
 type CreateGroupModalProps = {
@@ -15,19 +15,10 @@ export default function CreateGroupModal({
 }: CreateGroupModalProps) {
   //group input 값
   const [groupName, setGroupName] = useState("");
-
-  const [showInviteCode, setShowInviteCode] = useState(false);
-  const [inviteCode, setInviteCode] = useState("");
-  const [copied, setCopied] = useState(false);
-
   const [imageFile, setImageFile] = useState<File | null>(null);
-
+  const [inviteCode, setInviteCode] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-
-  const handleShowCode = () => {
-    setShowInviteCode(true);
-    setCopied(false);
-  };
+  const [copied, setCopied] = useState(false);
 
   const handleCreateGroup = async () => {
     if (!groupName.trim()) {
@@ -38,19 +29,16 @@ export default function CreateGroupModal({
     setIsLoading(true);
 
     try {
-      const response = await createGroup(2, {
+      const defaultImageUrl =
+        "https://grit-s3.ap-northeast-2.amazonaws.com/profile/default.png";
+      const response = await groupApi.create({
         name: groupName,
-        imageUrl: imageFile
-          ? "업로드된_URL" // 실제로는 먼저 이미지 업로드 후 URL 받아야 함
-          : "https://grit-s3.ap-northeast-2.amazonaws.com/profile/default.png",
+        imageUrl: defaultImageUrl,
       });
-
-      console.log("그룹 생성 성공:", response);
-
       setInviteCode(response.inviteCode);
-      setShowInviteCode(true);
-    } catch (err) {
-      console.error("그룹 생성 실패:", err);
+      setCopied(false);
+    } catch (e) {
+      console.error("그룹 생성 실패:", e);
       alert("그룹 생성에 실패했습니다");
     } finally {
       setIsLoading(false);
@@ -67,12 +55,11 @@ export default function CreateGroupModal({
     }
   };
 
-  //모달 닫을 때 전체 초기화
   const handleClose = () => {
     setGroupName("");
     setImageFile(null);
-    setShowInviteCode(false);
     setInviteCode("");
+    setCopied(false);
     onClose();
   };
 
@@ -87,10 +74,7 @@ export default function CreateGroupModal({
         </Modal.Header>
 
         <Modal.Body className="px-8 flex flex-col items-center pb-8">
-          <ImageUploader
-            size={160}
-            onImageChange={(file) => setImageFile(file)}
-          />
+          <ImageUploader size={160} onImageChange={setImageFile} />
           <div className="mx-auto mt-10 w-full max-w-[360px]">
             <label className="mb-2 block text-sm font-medium text-[#D6FDE5]">
               그룹 이름
@@ -118,7 +102,7 @@ export default function CreateGroupModal({
             </p>
           </div>
 
-          {showInviteCode && (
+          {inviteCode && (
             <div className="mt-6 flex items-center gap-1 rounded-xl bg-white px-4 py-2">
               <span className="text-sm font-bold text-[#3E7358]">
                 {inviteCode}

--- a/frontend/src/pages/Home/components/Modals/GroupSettingsModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/GroupSettingsModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import Modal from "@/components/Modal";
-import { updateGroup } from "@/apis/services/group";
+import { groupApi } from "@/apis/services/group";
 import { ImageUploader } from "@/components/ImageUploader";
 
 type GroupSettingsModalProps = {
@@ -22,34 +22,31 @@ export default function GroupSettingsModal({
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
-  //저장 버튼 핸들러
-  const handleSave = async () => {
-    if (!groupName.trim()) {
-      alert("그룹 이름을 입력해주세요.");
-      return;
-    }
+  const handleClose = () => {
+    setGroupName(initialName);
+    setImageFile(null);
+    setIsLoading(false);
+    onClose();
+  };
 
+  const handleSave = async () => {
+    if (!groupName.trim()) return;
     setIsLoading(true);
     try {
-      const response = await updateGroup(groupId, 1, {
-        name: groupName,
+      await groupApi.update(groupId, {
+        name: groupName.trim(),
         imageUrl: imageFile
           ? "업로드된_URL"
           : initialImage ||
             "https://grit-s3.ap-northeast-2.amazonaws.com/profile/default.png",
       });
-
-      console.log("그룹 정보 수정 성공", response);
-      alert("그룹 정보 수정 성공"); //나중에 toast로 변경
-      onClose();
+      handleClose();
     } catch (error) {
       console.error("그룹 정보 수정 실패:", error);
-      alert("그룹 정보 수정 실패");
     } finally {
       setIsLoading(false);
     }
   };
-
   return (
     <Modal isOpen={open} onClose={onClose}>
       <Modal.Overlay />


### PR DESCRIPTION
## 변경점
- `src/apis/types/group.ts`의 DTO 구조를 리팩토링하여 타입 중복을 제거하고 역할을 분리하였습니다.
- group API를 **groupApi 객체 패턴**으로 정리해 호출 방식을 통일하였습니다.
    ```
    groupApi.create(data)
    groupApi.update(groupId, data)
    ```
- 도메인 별로 계층을 나누어 endpoint를 리팩토링하였습니다.
    ```
    export const API_ENDPOINTS = {
      AUTH: {
        GOOGLE: "/api/auth/google",
        REFRESH: "/api/auth/refresh",
        LOGOUT: "/api/auth/logout",
      },
      GROUP: {
        BASE: "/api/groups",
        DETAIL: (id: number) => `/api/groups/${id}`,
      },
    } as const;
    
    ```