### PR TITLE
feat: 히어로 섹션 handlewheel 추가

### DIFF
--- a/frontend/src/pages/Landing/components/IntroductionSection/IntroductionSection.tsx
+++ b/frontend/src/pages/Landing/components/IntroductionSection/IntroductionSection.tsx
@@ -1,55 +1,20 @@
-import { useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
 import IntroductionCard from "@/pages/Landing/components/IntroductionSection/IntroductionCard";
 
-export default function IntroductionSection() {
-  const sectionsRef = useRef<(HTMLElement | null)[]>([]);
-  const [currentSection, setCurrentSection] = useState(0);
-  const isScrollingRef = useRef(false);
+type IntroductionSectionProps = {
+  sectionsRef: RefObject<(HTMLElement | null)[]>;
+  startIndex?: number;
+};
 
-  useEffect(() => {
-    const handleWheel = (e: WheelEvent) => {
-      if (isScrollingRef.current) {
-        e.preventDefault();
-        return;
-      }
-
-      const delta = e.deltaY;
-      let nextSection = currentSection;
-
-      if (delta > 0 && currentSection < sectionsRef.current.length - 1) {
-        nextSection = currentSection + 1;
-      } else if (delta < 0 && currentSection > 0) {
-        nextSection = currentSection - 1;
-      }
-
-      if (nextSection !== currentSection) {
-        e.preventDefault();
-        isScrollingRef.current = true;
-        setCurrentSection(nextSection);
-
-        sectionsRef.current[nextSection]?.scrollIntoView({
-          behavior: "smooth",
-          block: "center",
-        });
-
-        setTimeout(() => {
-          isScrollingRef.current = false;
-        }, 1500);
-      }
-    };
-
-    window.addEventListener("wheel", handleWheel, { passive: false });
-
-    return () => {
-      window.removeEventListener("wheel", handleWheel);
-    };
-  }, [currentSection]);
-
+export default function IntroductionSection({
+  sectionsRef,
+  startIndex = 1,
+}: IntroductionSectionProps) {
   return (
     <>
       <section
         ref={(sec) => {
-          sectionsRef.current[0] = sec;
+          sectionsRef.current[startIndex] = sec;
         }}
         className="h-screen"
       >
@@ -61,7 +26,7 @@ export default function IntroductionSection() {
 
       <section
         ref={(sec) => {
-          sectionsRef.current[1] = sec;
+          sectionsRef.current[startIndex + 1] = sec;
         }}
         className="h-screen"
       >
@@ -73,7 +38,7 @@ export default function IntroductionSection() {
 
       <section
         ref={(sec) => {
-          sectionsRef.current[2] = sec;
+          sectionsRef.current[startIndex + 2] = sec;
         }}
         className="h-screen"
       >

--- a/frontend/src/pages/Landing/index.tsx
+++ b/frontend/src/pages/Landing/index.tsx
@@ -1,13 +1,61 @@
+import { useEffect, useRef } from "react";
 import HeroSection from "@/pages/Landing/components/HeroSection/HeroSection";
 import IntroductionSection from "@/pages/Landing/components/IntroductionSection/IntroductionSection";
 import { Header } from "@/components/Header";
 
 const LandingPage = () => {
+  const sectionsRef = useRef<(HTMLElement | null)[]>([]);
+  const currentIndexRef = useRef(0);
+  const isScrollingRef = useRef(false);
+
+  useEffect(() => {
+    const handleWheel = (e: WheelEvent) => {
+      if (isScrollingRef.current) {
+        e.preventDefault();
+        return;
+      }
+
+      const delta = e.deltaY;
+      const total = sectionsRef.current.length;
+      let nextIndex = currentIndexRef.current;
+
+      if (delta > 0 && nextIndex < total - 1) nextIndex++;
+      else if (delta < 0 && nextIndex > 0) nextIndex--;
+
+      if (nextIndex !== currentIndexRef.current) {
+        e.preventDefault();
+        currentIndexRef.current = nextIndex;
+        isScrollingRef.current = true;
+
+        sectionsRef.current[nextIndex]?.scrollIntoView({
+          behavior: "smooth",
+          block: "center",
+        });
+
+        setTimeout(() => {
+          isScrollingRef.current = false;
+        }, 1000);
+      }
+    };
+
+    window.addEventListener("wheel", handleWheel, { passive: false });
+
+    return () => {
+      window.removeEventListener("wheel", handleWheel);
+    };
+  }, []);
+
   return (
     <>
       <Header variant="light" />
-      <HeroSection />
-      <IntroductionSection />
+      <section
+        ref={(el) => {
+          sectionsRef.current[0] = el;
+        }}
+      >
+        <HeroSection />
+      </section>
+      <IntroductionSection sectionsRef={sectionsRef} startIndex={1} />
     </>
   );
 };


### PR DESCRIPTION
## 변경점
- wheel 스냅 제어를 `IntroductionSection`에서 `Landing/index.tsx`로 이동하여 Hero+Introduction을 동일 인덱스 기준으로 스크롤 되도록 수정하였습니다.

## 개선점
-  Hero에서 휠 시 Introduction 두번째로 점프하던 현상을 해결하였습니다.

## 테스트
- [x] Hero에서 휠: Hero → Intro 1번째로 이동하는지 확인
- [x] Intro 각 섹션에서 휠: “휠 1번당 1섹션” 동작 확인