### PR TITLE
fix: 회원 탈퇴 시 기타 정보 미삭제로 인한 FK violation 발생으로 DataIntegrityViolationException 발생하는 문제 해결

### DIFF
--- a/backend/grit/src/main/java/grit/domain/auth/repository/RefreshTokenRepository.java
+++ b/backend/grit/src/main/java/grit/domain/auth/repository/RefreshTokenRepository.java
@@ -9,4 +9,5 @@ import org.springframework.stereotype.Repository;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByToken(String token);
     void deleteByToken(String token);
+    void deleteAllByMember(grit.domain.member.entity.Member member);
 }

--- a/backend/grit/src/main/java/grit/domain/member/service/MemberService.java
+++ b/backend/grit/src/main/java/grit/domain/member/service/MemberService.java
@@ -4,6 +4,7 @@ import grit.domain.member.constant.Role;
 import grit.domain.member.constant.SocialProvider;
 import grit.domain.member.dto.MemberProfileImageUploadUrlResponseDto;
 import grit.domain.member.entity.Member;
+import grit.domain.auth.repository.RefreshTokenRepository;
 import grit.domain.member.repository.MemberRepository;
 import grit.global.exception.EntityNotFoundException;
 import grit.global.s3.S3Directory;
@@ -24,6 +25,7 @@ import org.springframework.stereotype.Service;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final S3Service s3Service;
 
     // 회원 가입
@@ -106,6 +108,7 @@ public class MemberService {
 
     // 회원 탈퇴
     public void delete(Member member) {
+        refreshTokenRepository.deleteAllByMember(member);
         memberRepository.delete(member);
     }
 


### PR DESCRIPTION
# 변경점 👍
회원 탈퇴 시 RefreshToken 미삭제 상태에서 Member 삭제로 인한 FK violation 발생으로 DataIntegrityViolationException 예외 발생하는 문제 해결

<img width="1773" height="184" alt="image" src="https://github.com/user-attachments/assets/283562a3-83d4-405c-8feb-bf4483900e28" />
