### PR TITLE
feat: 헤더 드롭다운 구현 및 내 정보 조회 api 연동

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "axios": "^1.13.2",
         "framer-motion": "^12.34.0",
         "livekit-client": "^2.16.0",
-        "lucide-react": "^0.554.0",
+        "lucide-react": "^1.0.0-rc.0",
         "motion": "^12.34.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -3668,9 +3668,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.554.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.554.0.tgz",
-      "integrity": "sha512-St+z29uthEJVx0Is7ellNkgTEhaeSoA42I7JjOCBCrc5X6LYMGSv0P/2uS5HDLTExP5tpiqRD2PyUEOS6s9UXA==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.0.0-rc.0.tgz",
+      "integrity": "sha512-XUO9emKjDQ5gmA0dLS8vJCeBFh3FTWIgua4g8nI+RcFneUhQjL/wueIUsVXSeQW339f8GGoHbXkq04R145ZKBA==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "axios": "^1.13.2",
     "framer-motion": "^12.34.0",
     "livekit-client": "^2.16.0",
-    "lucide-react": "^0.554.0",
+    "lucide-react": "^1.0.0-rc.0",
     "motion": "^12.34.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/frontend/src/apis/constants/endpoints.ts
+++ b/frontend/src/apis/constants/endpoints.ts
@@ -6,6 +6,7 @@ export const API_ENDPOINTS = {
     GOOGLE: "/api/auth/google",
     REFRESH: "/api/auth/refresh",
     LOGOUT: "/api/auth/logout",
+    SIGNOUT: "/api/members/me",
   },
   GROUP: {
     BASE: "/api/groups",

--- a/frontend/src/apis/constants/endpoints.ts
+++ b/frontend/src/apis/constants/endpoints.ts
@@ -6,7 +6,7 @@ export const API_ENDPOINTS = {
     GOOGLE: "/api/auth/google",
     REFRESH: "/api/auth/refresh",
     LOGOUT: "/api/auth/logout",
-    SIGNOUT: "/api/members/me",
+    INFO: "/api/members/me",
   },
   GROUP: {
     BASE: "/api/groups",

--- a/frontend/src/apis/services/auth.ts
+++ b/frontend/src/apis/services/auth.ts
@@ -19,15 +19,12 @@ export const loginGoogle = async (
     code,
     redirectUri: OAUTH_CONFIG.GOOGLE.REDIRECT_URI,
   };
-
   const response = await apiClient.post<GoogleLoginResponse>(
     API_ENDPOINTS.AUTH.GOOGLE,
     requestBody,
     { withCredentials: true },
   );
-
   const { member, accessToken, firstTimeUser } = response.data;
-
   const authStorage = {
     state: {
       accessToken,
@@ -35,7 +32,6 @@ export const loginGoogle = async (
     },
   };
   localStorage.setItem("auth-storage", JSON.stringify(authStorage));
-
   console.log({
     memberId: member.id,
     nickname: member.nickname,

--- a/frontend/src/apis/services/auth.ts
+++ b/frontend/src/apis/services/auth.ts
@@ -92,3 +92,16 @@ export const logout = async (): Promise<void> => {
     console.log("로컬 데이터 삭제");
   }
 };
+
+export const signout = async (): Promise<void> => {
+  try {
+    await apiClient.delete(API_ENDPOINTS.AUTH.SIGNOUT, {});
+    console.log("탈퇴 성공");
+  } catch (error) {
+    console.error(error);
+    console.log("탈퇴 실패");
+  } finally {
+    localStorage.removeItem("auth-storage");
+    console.log("로컬 데이터 삭제");
+  }
+};

--- a/frontend/src/apis/services/auth.ts
+++ b/frontend/src/apis/services/auth.ts
@@ -9,12 +9,9 @@ import { OAUTH_CONFIG } from "@/apis/constants/oauth";
 import { API_ENDPOINTS } from "@/apis/constants/endpoints";
 import type { RefreshTokenResponse } from "@/apis/types/auth";
 
-//구글에서 받은 code를 백엔드로 전송
-//토큰과 사용자 정보를 받아오기
 export const loginGoogle = async (
   code: string,
 ): Promise<GoogleLoginResponse> => {
-  //백엔드에게 보낼 데이터를 객체로 만들기
   const requestBody: GoogleLoginRequest = {
     code,
     redirectUri: OAUTH_CONFIG.GOOGLE.REDIRECT_URI,
@@ -41,7 +38,6 @@ export const loginGoogle = async (
   return response.data;
 };
 
-//리프레시 토큰
 export const refreshAccessToken = async (): Promise<string> => {
   const response = await apiClient.post<RefreshTokenResponse>(
     API_ENDPOINTS.AUTH.REFRESH,
@@ -59,49 +55,19 @@ export const refreshAccessToken = async (): Promise<string> => {
   return accessToken;
 };
 
-//로그인한 사용자 정보 가져오기
-export const getCurrentUser = (): Member | null => {
-  try {
-    const authStorage = localStorage.getItem("auth-storage");
-    if (!authStorage) return null;
-
-    const { state } = JSON.parse(authStorage);
-    return state?.member || null;
-  } catch (error) {
-    console.error("사용자 정보 오류", error);
-    return null;
-  }
+export const getUserInfo = async (): Promise<Member> => {
+  const response = await apiClient.get<Member>(API_ENDPOINTS.AUTH.INFO);
+  return response.data;
 };
 
-//로그아웃
 export const logout = async (): Promise<void> => {
-  try {
-    await apiClient.post(
-      API_ENDPOINTS.AUTH.LOGOUT,
-      {},
-      {
-        withCredentials: true,
-      },
-    );
-    console.log("로그아웃 성공");
-  } catch (error) {
-    console.error(error);
-    console.log("로그아웃 실패");
-  } finally {
-    localStorage.removeItem("auth-storage");
-    console.log("로컬 데이터 삭제");
-  }
+  await apiClient.post(API_ENDPOINTS.AUTH.LOGOUT, {
+    withCredentials: true,
+  });
+  localStorage.removeItem("auth-storage");
 };
 
 export const signout = async (): Promise<void> => {
-  try {
-    await apiClient.delete(API_ENDPOINTS.AUTH.SIGNOUT, {});
-    console.log("탈퇴 성공");
-  } catch (error) {
-    console.error(error);
-    console.log("탈퇴 실패");
-  } finally {
-    localStorage.removeItem("auth-storage");
-    console.log("로컬 데이터 삭제");
-  }
+  await apiClient.delete(API_ENDPOINTS.AUTH.INFO);
+  localStorage.removeItem("auth-storage");
 };

--- a/frontend/src/apis/types/auth.ts
+++ b/frontend/src/apis/types/auth.ts
@@ -4,9 +4,10 @@ export interface Member {
   nickname: string;
   email: string;
   introduction: string;
-  dDayDate: string;
-  dDayTitle: string;
-  weeklyStudyTimeGoal: string;
+  imageUrl?: string;
+  dDayDate?: string;
+  dDayTitle?: string;
+  weeklyStudyTimeGoal?: string;
 }
 export interface GoogleLoginRequest {
   code: string;

--- a/frontend/src/apis/types/index.ts
+++ b/frontend/src/apis/types/index.ts
@@ -1,1 +1,2 @@
 export * from "@/apis/types/group";
+export * from "@/apis/types/auth";

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -2,7 +2,8 @@ import { ChevronDown, ChevronUp } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { PATHS } from "@/routes/path";
-import { getCurrentUser, logout, signout } from "@/apis/services/auth";
+import type { Member } from "@/apis/types";
+import { getUserInfo, logout, signout } from "@/apis/services/auth";
 
 type HeaderProps = {
   variant: "light" | "dark";
@@ -13,7 +14,24 @@ export function Header({ variant, alwaysVisible = false }: HeaderProps) {
   const [isHeaderVisible, setIsHeaderVisible] = useState(alwaysVisible);
   const [isDropDownOpen, SetIsDropDownOpen] = useState(false);
   const navigate = useNavigate();
-  const user = getCurrentUser();
+  const [user, setUser] = useState<Member | null>(null);
+
+useEffect(() => {
+    let mounted = true;
+    const fetchUser = async () => {
+      try {
+        const data = await getUserInfo();
+        if (mounted) setUser(data);
+      } catch (error) {
+        if (mounted) setUser(null);
+        console.error("유저 정보 조회 실패", error);
+      }
+    };
+    fetchUser();
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (alwaysVisible) return;

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,7 +1,8 @@
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { PATHS } from "@/routes/path";
-import { getCurrentUser, logout } from "@/apis/services/auth";
+import { getCurrentUser, logout, signout } from "@/apis/services/auth";
 
 type HeaderProps = {
   variant: "light" | "dark";
@@ -10,6 +11,7 @@ type HeaderProps = {
 
 export function Header({ variant, alwaysVisible = false }: HeaderProps) {
   const [isHeaderVisible, setIsHeaderVisible] = useState(alwaysVisible);
+  const [isDropDownOpen, SetIsDropDownOpen] = useState(false);
   const navigate = useNavigate();
   const user = getCurrentUser();
 
@@ -44,12 +46,25 @@ export function Header({ variant, alwaysVisible = false }: HeaderProps) {
 
   const currentStyle = styles[variant];
 
+  const toggleDropdown = () => {
+    SetIsDropDownOpen((prev) => !prev);
+  };
+
   const handleLogout = async () => {
     try {
       await logout();
       navigate(PATHS.SIGNUP);
     } catch (error) {
       console.error("로그아웃 실패", error);
+    }
+  };
+
+  const handleSignout = async () => {
+    try {
+      await signout();
+      navigate(PATHS.SIGNUP);
+    } catch (error) {
+      console.error("회원탈퇴 실패", error);
     }
   };
 
@@ -70,28 +85,55 @@ export function Header({ variant, alwaysVisible = false }: HeaderProps) {
               <span className={`text-sm ${currentStyle.userInfo}`}>
                 {user.nickname || user.email}님
               </span>
-              <button
+              {/* <button
                 onClick={handleLogout}
                 className="px-6 py-2 rounded-lg bg-green-semidark/80 text-white text-sm shadow-md hover:bg-green-semidark transition cursor-pointer"
               >
                 로그아웃
-              </button>
+              </button> */}
+              {/* 드롭다운 컴포넌트 */}
+              <div className="relative">
+                <button
+                  type="button"
+                  onClick={toggleDropdown}
+                  className={`p-1 rounded-full transition cursor-pointer ${
+                    isDropDownOpen ? "bg-white/20" : "hover:bg-white/20"
+                  }`}
+                >
+                  {isDropDownOpen ? (
+                    <ChevronUp size={18} className="text-gray-50" />
+                  ) : (
+                    <ChevronDown size={18} className="text-gray-50" />
+                  )}
+                </button>
+
+                {isDropDownOpen && (
+                  <div className="absolute bg-[#2B2F36] right-0 mt-6 w-28  rounded-lg shadow-lg border-none p-1 z-50">
+                    <button
+                      type="button"
+                      className="text-white w-full px-4 py-2 text-center text-sm text-gray-700 hover:bg-gray-900 hover:rounded-md transition"
+                      onClick={handleLogout}
+                    >
+                      로그아웃
+                    </button>
+                    <button
+                      type="button"
+                      className="w-full px-4 py-2 text-center text-sm text-red-500 hover:bg-gray-900"
+                      onClick={handleSignout}
+                    >
+                      탈퇴하기
+                    </button>
+                  </div>
+                )}
+              </div>
             </>
           ) : (
-            <>
-              <button
-                onClick={() => navigate(PATHS.SIGNUP)}
-                className="px-6 py-2 rounded-lg bg-green-semidark/80 text-white text-sm shadow-md hover:bg-green-semidark transition cursor-pointer"
-              >
-                GRIT 시작하기
-              </button>
-              {/* <button
-                onClick={() => navigate(PATHS.SIGNUP)}
-                className="px-6 py-2 rounded-lg bg-green-semidark/80 text-white text-sm shadow-md hover:bg-green-semidark transition cursor-pointer"
-              >
-                회원가입
-              </button> */}
-            </>
+            <button
+              onClick={() => navigate(PATHS.SIGNUP)}
+              className="px-6 py-2 rounded-lg bg-green-semidark/80 text-white text-sm shadow-md hover:bg-green-semidark transition cursor-pointer"
+            >
+              GRIT 시작하기
+            </button>
           )}
         </div>
       </div>

--- a/frontend/src/pages/OAuthRedirect/index.tsx
+++ b/frontend/src/pages/OAuthRedirect/index.tsx
@@ -51,7 +51,7 @@ const GoogleOAuthRedirectPage = () => {
         }
       } catch (error) {
         await minLoadingTime;
-        console.error("9로그인 도중 오류", error);
+        console.error("로그인 도중 오류", error);
         alert("오류");
         navigate(PATHS.SIGNUP);
       }


### PR DESCRIPTION
## 변경점 
- 헤더 드롭다운 컴포넌트를 구현하였습니다.
- 회원탈퇴 api를 연동하였습니다.
- 내 정보 조회 api를 연동하였습니다.

## 개선점
- 내 정보 조회 api의 response로 받아온 data에서 최초 가입자일 경우 nickname 값이 null일 것을 고려하여 `user.nickname || user.email` 을 받아오도록 하였습니다.
- 회원 탈퇴 UI 레이어를 한 단계 숨겨두고자 드롭다운 컴포넌트를 구현하여, 내부에 회원 탈퇴 기능과 로그아웃 기능을 추가하였습니다.

  <img width="328" height="164" alt="스크린샷 2026-03-21 오후 10 36 27" src="https://github.com/user-attachments/assets/baee8a84-a3c8-4b60-a854-73082af81184" />


## 테스트 
- [x] 내 정보 조회 api 동작 테스트
- [ ] 회원 탈퇴 api 동작 테스트 (백엔드 API 수정중 🛠️ )