### PR TITLE
refactor: 클라이언트에 그룹 ID 반환하지 않도록 수정, 그룹 초대 코드에서 그룹 코드로 변경 및 관련 API 수정

### DIFF
--- a/backend/grit/src/main/java/grit/domain/group/GroupController.java
+++ b/backend/grit/src/main/java/grit/domain/group/GroupController.java
@@ -3,7 +3,11 @@ package grit.domain.group;
 import grit.domain.auth.infrastructure.jwt.MemberPrincipal;
 import grit.domain.group.dto.GroupCreateRequestDto;
 import grit.domain.group.dto.GroupInfoResponseDto;
+import grit.domain.group.dto.GroupProfileImageUploadUrlResponseDto;
 import grit.domain.group.dto.GroupUpdateRequestDto;
+import grit.domain.group.entity.Group;
+import grit.domain.member.entity.Member;
+import grit.domain.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -27,6 +31,7 @@ import java.util.List;
 public class GroupController {
 
     private final GroupService groupService;
+    private final MemberService memberService;
     private final S3Service s3Service;
 
     @Operation(summary = "그룹 생성", description = "새로운 그룹을 생성합니다.")
@@ -40,38 +45,40 @@ public class GroupController {
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
             @RequestBody GroupCreateRequestDto request) {
 
-        GroupInfoResponseDto response = groupService.createGroup(memberPrincipal.id(), request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(resolveImageUrl(response));
+        Member member = memberService.findMemberById(memberPrincipal.id());
+        Group group = groupService.createGroup(member, request.getName(), request.getImageName());
+        return ResponseEntity.status(HttpStatus.CREATED).body(toResponseDto(group));
     }
 
-    @Operation(summary = "그룹 가입", description = "초대 코드를 입력하여 그룹에 참여합니다.")
+    @Operation(summary = "그룹 가입", description = "그룹 코드를 입력하여 그룹에 참여합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "가입 성공"),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 그룹 또는 사용자", content = @Content),
             @ApiResponse(responseCode = "409", description = "이미 가입된 그룹", content = @Content)
     })
-    @PostMapping("/join/code")
+    @PostMapping("/{groupCode}/join")
     public ResponseEntity<GroupInfoResponseDto> joinGroup(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
-            @Parameter(description = "가입할 그룹의 초대 코드", example = "10")
-            @RequestParam String inviteCode) {
+            @Parameter(description = "가입할 그룹의 그룹 코드", example = "ABCD12")
+            @PathVariable String groupCode) {
 
-        GroupInfoResponseDto response = groupService.joinGroup(memberPrincipal.id(), inviteCode);
-        return ResponseEntity.ok(resolveImageUrl(response));
+        Member member = memberService.findMemberById(memberPrincipal.id());
+        Group group = groupService.joinGroup(member, groupCode);
+        return ResponseEntity.ok(toResponseDto(group));
     }
 
-    @Operation(summary = "그룹 상세 조회", description = "특정 그룹의 상세 정보를 조회합니다.")
+    @Operation(summary = "그룹 상세 조회", description = "그룹 코드를 이용하여 특정 그룹의 상세 정보를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 그룹 ID", content = @Content)
+            @ApiResponse(responseCode = "404", description = "유효하지 않은 그룹 코드", content = @Content)
     })
-    @GetMapping("/{groupId}")
+    @GetMapping("/{groupCode}")
     public ResponseEntity<GroupInfoResponseDto> getGroup(
-            @Parameter(description = "조회할 그룹 ID", example = "10")
-            @PathVariable Long groupId) {
+            @Parameter(description = "조회할 그룹의 그룹 코드", example = "ABCD12")
+            @PathVariable String groupCode) {
 
-        GroupInfoResponseDto response = groupService.getGroup(groupId);
-        return ResponseEntity.ok(resolveImageUrl(response));
+        Group group = groupService.findGroupByCode(groupCode);
+        return ResponseEntity.ok(toResponseDto(group));
     }
 
     @Operation(summary = "내 그룹 목록 조회", description = "내가 속한 모든 그룹 목록을 조회합니다.")
@@ -80,9 +87,10 @@ public class GroupController {
     public ResponseEntity<List<GroupInfoResponseDto>> getMyGroups(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
 
-        List<GroupInfoResponseDto> response = groupService.getMyGroups(memberPrincipal.id())
+        Member member = memberService.findMemberById(memberPrincipal.id());
+        List<GroupInfoResponseDto> response = groupService.getMyGroups(member)
                 .stream()
-                .map(this::resolveImageUrl)
+                .map(this::toResponseDto)
                 .toList();
         return ResponseEntity.ok(response);
     }
@@ -91,32 +99,32 @@ public class GroupController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "수정 성공"),
             @ApiResponse(responseCode = "403", description = "수정 권한 없음", content = @Content),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 그룹 ID", content = @Content)
+            @ApiResponse(responseCode = "404", description = "유효하지 않은 그룹 코드", content = @Content)
     })
-    @PutMapping("/{groupId}")
+    @PutMapping("/{groupCode}")
     public ResponseEntity<GroupInfoResponseDto> updateGroup(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
-            @Parameter(description = "수정할 그룹 ID", example = "10")
-            @PathVariable Long groupId,
+            @Parameter(description = "수정할 그룹의 그룹 코드", example = "ABCD12")
+            @PathVariable String groupCode,
             @RequestBody GroupUpdateRequestDto updateRequest) {
 
-        groupService.updateGroup(memberPrincipal.id(), groupId, updateRequest);
-
-        GroupInfoResponseDto response = groupService.getGroup(groupId);
-        return ResponseEntity.ok(resolveImageUrl(response));
+        Member member = memberService.findMemberById(memberPrincipal.id());
+        Group group = groupService.updateGroupByCode(member, groupCode, updateRequest.getName(), updateRequest.getImageName());
+        return ResponseEntity.ok(toResponseDto(group));
     }
 
     @Operation(summary = "그룹 나가기 (삭제)", description = "그룹을 탈퇴합니다. 해당 그룹 멤버의 인원이 0명이 되면 그룹이 자동 삭제됩니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "탈퇴/삭제 성공 (반환값 없음)"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 그룹 또는 사용자", content = @Content)
+            @ApiResponse(responseCode = "404", description = "유효하지 않은 그룹 코드 또는 사용자", content = @Content)
     })
-    @DeleteMapping("/{groupId}")
+    @DeleteMapping("/{groupCode}")
     public ResponseEntity<Void> leaveGroup(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
-            @PathVariable Long groupId) {
+            @PathVariable String groupCode) {
 
-        groupService.deleteGroup(memberPrincipal.id(), groupId);
+        Member member = memberService.findMemberById(memberPrincipal.id());
+        groupService.deleteGroupByCode(member, groupCode);
         return ResponseEntity.noContent().build();
     }
 
@@ -126,21 +134,15 @@ public class GroupController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content)
     })
     @GetMapping("/image-upload-url")
-    public ResponseEntity<grit.domain.group.dto.GroupProfileImageUploadUrlResponseDto> getGroupImageUploadUrl() {
+    public ResponseEntity<GroupProfileImageUploadUrlResponseDto> getGroupImageUploadUrl() {
         return ResponseEntity.ok(groupService.generateGroupImageUploadUrl());
     }
 
-    private GroupInfoResponseDto resolveImageUrl(GroupInfoResponseDto dto) {
-        if (dto.getImageUrl() == null) {
-            return dto;
+    private GroupInfoResponseDto toResponseDto(Group group) {
+        String imageUrl = null;
+        if (group.getImageName() != null) {
+            imageUrl = s3Service.resolveUrl(S3Directory.GROUP_IMAGES, group.getImageName().toString());
         }
-        String resolvedUrl = s3Service.resolveUrl(S3Directory.GROUP_IMAGES, dto.getImageUrl());
-        return new GroupInfoResponseDto(
-                dto.getId(),
-                dto.getName(),
-                dto.getInviteCode(),
-                dto.getMemberCount(),
-                resolvedUrl
-        );
+        return new GroupInfoResponseDto(group.getName(), group.getCode(), group.getMemberCount(), imageUrl);
     }
 }

--- a/backend/grit/src/main/java/grit/domain/group/GroupService.java
+++ b/backend/grit/src/main/java/grit/domain/group/GroupService.java
@@ -1,22 +1,22 @@
 package grit.domain.group;
 
-import grit.domain.member.entity.Member;
-import grit.global.util.InviteCodeGenerator;
-import grit.domain.group.dto.GroupCreateRequestDto;
-import grit.domain.group.dto.GroupInfoResponseDto;
-import grit.domain.group.dto.GroupUpdateRequestDto;
+import grit.domain.group.dto.GroupProfileImageUploadUrlResponseDto;
 import grit.domain.group.entity.Group;
 import grit.domain.group.entity.MemberGroup;
 import grit.domain.group.repository.GroupRepository;
 import grit.domain.group.repository.MemberGroupRepository;
-import grit.domain.member.repository.MemberRepository;
+import grit.domain.member.entity.Member;
+import grit.global.exception.AccessDeniedException;
 import grit.global.s3.S3Directory;
 import grit.global.s3.S3Service;
+import grit.global.util.GroupCodeGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
@@ -24,25 +24,19 @@ public class GroupService {
 
     private final GroupRepository groupRepository;
     private final MemberGroupRepository memberGroupRepository;
-    private final MemberRepository memberRepository;
     private final S3Service s3Service;
 
-    // 그룹 생성
     @Transactional
-    public GroupInfoResponseDto createGroup(Long userId, GroupCreateRequestDto groupRequest) {
-        Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-
-        if (groupRequest.getImageName() != null && !s3Service.isObjectExists(S3Directory.GROUP_IMAGES, groupRequest.getImageName().toString())) {
+    public Group createGroup(Member member, String name, UUID imageName) {
+        if (imageName != null && !s3Service.isObjectExists(S3Directory.GROUP_IMAGES, imageName.toString())) {
             throw new IllegalArgumentException("유효하지 않은 그룹 이미지입니다.");
         }
 
-        String inviteCode = generateInviteCode();
-
+        String groupCode = generateGroupCode();
         Group group = Group.builder()
-                .name(groupRequest.getName())
-                .imageName(groupRequest.getImageName())
-                .inviteCode(inviteCode)
+                .name(name)
+                .imageName(imageName)
+                .code(groupCode)
                 .build();
 
         group.increaseMemberCount();
@@ -54,33 +48,28 @@ public class GroupService {
                 .build();
         memberGroupRepository.save(memberGroup);
 
-        return new GroupInfoResponseDto(savedGroup, getRawImageUrl(savedGroup));
+        return savedGroup;
     }
 
-    private String generateInviteCode() {
+    private String generateGroupCode() {
         String code;
         int retryCount = 0;
         do {
-            code = InviteCodeGenerator.generate();
+            code = GroupCodeGenerator.generate();
             retryCount++;
             if (retryCount > 10) {
-                throw new IllegalStateException("초대 코드 생성에 실패했습니다. 잠시 후 다시 시도해주세요.");
+                throw new IllegalStateException("그룹 코드 생성에 실패했습니다. 잠시 후 다시 시도해주세요.");
             }
-        } while (groupRepository.existsByInviteCode(code));
+        } while (groupRepository.existsByCode(code));
         return code;
     }
 
-    // 그룹 가입
     @Transactional
-    public GroupInfoResponseDto joinGroup(Long userId, String inviteCode) {
-        Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+    public Group joinGroup(Member member, String groupCode) {
+        Group group = groupRepository.findByCode(groupCode)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 그룹 코드입니다."));
 
-        Group group = groupRepository.findByInviteCode(inviteCode)
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 초대 코드입니다."));
-
-        boolean isAlreadyMember = memberGroupRepository.existsByMemberIdAndGroupId(userId,
-                group.getId());
+        boolean isAlreadyMember = memberGroupRepository.existsByMemberAndGroup(member, group);
         if (isAlreadyMember) {
             throw new IllegalStateException("이미 가입된 그룹입니다.");
         }
@@ -93,16 +82,16 @@ public class GroupService {
         memberGroupRepository.save(memberGroup);
         group.increaseMemberCount();
 
-        return new GroupInfoResponseDto(group, getRawImageUrl(group));
+        return group;
     }
 
-    // 그룹 나가기(삭제)
     @Transactional
-    public void deleteGroup(Long userId, Long groupId) {
-        MemberGroup memberGroup = memberGroupRepository.findByMemberIdAndGroupId(userId, groupId)
-                .orElseThrow(() -> new IllegalArgumentException("참여 중인 그룹이 아닙니다."));
+    public void deleteGroupByCode(Member member, String groupCode) {
+        Group group = groupRepository.findByCode(groupCode)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 그룹 코드입니다."));
 
-        Group group = memberGroup.getGroup();
+        MemberGroup memberGroup = memberGroupRepository.findByMemberAndGroup(member, group)
+                .orElseThrow(() -> new IllegalArgumentException("참여 중인 그룹이 아닙니다."));
 
         memberGroupRepository.delete(memberGroup);
 
@@ -110,59 +99,49 @@ public class GroupService {
 
         if (group.getMemberCount() <= 0) {
             groupRepository.delete(group);
-            System.out.println("그룹 내의 인원이 0명이 되어 그룹이 자동 삭제되었습니다." + groupId);
         }
     }
 
-    // 그룹 정보 수정
     @Transactional
-    public void updateGroup(Long userId, Long groupId, GroupUpdateRequestDto updateRequest) {
-        boolean isMember = memberGroupRepository.existsByMemberIdAndGroupId(userId, groupId);
+    public Group updateGroupByCode(Member member, String groupCode, String name, UUID imageName) {
+        Group group = groupRepository.findByCode(groupCode)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 그룹 코드입니다."));
+
+        boolean isMember = memberGroupRepository.existsByMemberAndGroup(member, group);
         if (!isMember) {
-            throw new IllegalArgumentException("그룹 멤버만 수정할 수 있습니다.");
+            throw new AccessDeniedException("그룹 멤버만 수정할 수 있습니다.");
         }
 
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new IllegalArgumentException("그룹을 찾을 수 없습니다."));
-
-        if (updateRequest.getImageName() != null && !s3Service.isObjectExists(S3Directory.GROUP_IMAGES, updateRequest.getImageName().toString())) {
+        if (imageName != null && !s3Service.isObjectExists(S3Directory.GROUP_IMAGES, imageName.toString())) {
             throw new IllegalArgumentException("유효하지 않은 그룹 이미지입니다.");
         }
 
-        group.updateInfo(updateRequest.getName(), updateRequest.getImageName());
+        group.updateInfo(name, imageName);
+
+        return group;
     }
 
-    // 그룹 상세 조회
     @Transactional(readOnly = true)
-    public GroupInfoResponseDto getGroup(Long groupId) {
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new IllegalArgumentException("그룹을 찾을 수 없습니다."));
-
-        return new GroupInfoResponseDto(group, getRawImageUrl(group));
+    public Group findGroupByCode(String groupCode) {
+        return groupRepository.findByCode(groupCode)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 그룹 코드입니다."));
     }
 
-    // 사용자가 속한 모든 그룹 조회
     @Transactional(readOnly = true)
-    public List<GroupInfoResponseDto> getMyGroups(Long userId) {
-        List<MemberGroup> myMemberGroups = memberGroupRepository.findAllByMemberId(userId);
-
-        return myMemberGroups.stream()
-                .map(memberGroup -> new GroupInfoResponseDto(memberGroup.getGroup(), getRawImageUrl(memberGroup.getGroup())))
+    public List<Group> getMyGroups(Member member) {
+        return memberGroupRepository.findAllByMember(member).stream()
+                .map(MemberGroup::getGroup)
                 .toList();
     }
 
     @Transactional(readOnly = true)
-    public boolean isMemberInGroup(Member member, Long groupId) {
-        return memberGroupRepository.existsByMemberIdAndGroupId(member.getId(), groupId);
+    public boolean isMemberInGroup(Member member, Group group) {
+        return memberGroupRepository.existsByMemberAndGroup(member, group);
     }
 
-    public grit.domain.group.dto.GroupProfileImageUploadUrlResponseDto generateGroupImageUploadUrl() {
-        String fileName = java.util.UUID.randomUUID().toString();
-        String uploadUrl = s3Service.createSignedPutUrl(S3Directory.GROUP_IMAGES, fileName, java.time.Duration.ofMinutes(10)).toString();
-        return new grit.domain.group.dto.GroupProfileImageUploadUrlResponseDto(fileName, uploadUrl);
-    }
-
-    private String getRawImageUrl(Group group) {
-        return group.getImageName() != null ? group.getImageName().toString() : null;
+    public GroupProfileImageUploadUrlResponseDto generateGroupImageUploadUrl() {
+        String fileName = UUID.randomUUID().toString();
+        String uploadUrl = s3Service.createSignedPutUrl(S3Directory.GROUP_IMAGES, fileName, Duration.ofMinutes(10)).toString();
+        return new GroupProfileImageUploadUrlResponseDto(fileName, uploadUrl);
     }
 }

--- a/backend/grit/src/main/java/grit/domain/group/GroupService.java
+++ b/backend/grit/src/main/java/grit/domain/group/GroupService.java
@@ -64,7 +64,7 @@ public class GroupService {
             code = InviteCodeGenerator.generate();
             retryCount++;
             if (retryCount > 10) {
-                throw new IllegalStateException("초대 코드 생성을 10회 이상 시도하였으나 실패하였습니다.");
+                throw new IllegalStateException("초대 코드 생성에 실패했습니다. 잠시 후 다시 시도해주세요.");
             }
         } while (groupRepository.existsByInviteCode(code));
         return code;

--- a/backend/grit/src/main/java/grit/domain/group/dto/GroupInfoResponseDto.java
+++ b/backend/grit/src/main/java/grit/domain/group/dto/GroupInfoResponseDto.java
@@ -1,6 +1,5 @@
 package grit.domain.group.dto;
 
-import grit.domain.group.entity.Group;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,26 +7,15 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class GroupInfoResponseDto {
-    @Schema(description = "그룹 고유 ID (PK)", example = "10")
-    private final Long id;
-
     @Schema(description = "그룹 이름", example = "그룹 1")
     private final String name;
 
-    @Schema(description = "그룹 초대 코드", example = "23E!S@")
-    private final String inviteCode;
+    @Schema(description = "그룹 코드", example = "23ES4A")
+    private final String groupCode;
 
     @Schema(description = "현재 그룹원 수", example = "5")
     private final int memberCount;
 
     @Schema(description = "이미지 URL", example = "https://grit-s3.ap-northeast-2.amazonaws.com/profile/default.png", nullable = true)
     private final String imageUrl;
-
-    public GroupInfoResponseDto(Group group, String imageUrl) {
-        this.id = group.getId();
-        this.name = group.getName();
-        this.inviteCode = group.getInviteCode();
-        this.memberCount = group.getMemberCount();
-        this.imageUrl = imageUrl;
-    }
 }

--- a/backend/grit/src/main/java/grit/domain/group/entity/Group.java
+++ b/backend/grit/src/main/java/grit/domain/group/entity/Group.java
@@ -14,7 +14,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "groups", indexes = {
-        @Index(name = "idx_invite_code", columnList = "invite_code")
+        @Index(name = "idx_group_code", columnList = "code")
 })
 public class Group {
     @Id
@@ -25,7 +25,7 @@ public class Group {
     private String name;
 
     @Column(nullable = false, unique = true, length = 6)
-    private String inviteCode;
+    private String code;
 
     @Builder.Default
     @Column(nullable = false)

--- a/backend/grit/src/main/java/grit/domain/group/livekit/controller/LiveKitController2.java
+++ b/backend/grit/src/main/java/grit/domain/group/livekit/controller/LiveKitController2.java
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "LiveKit", description = "LiveKit 토큰 발급 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/group/{groupId}/livekit")
+@RequestMapping("/api/group/{groupCode}/livekit")
 public class LiveKitController2 {
 
     private final MemberService memberService;
@@ -47,10 +47,10 @@ public class LiveKitController2 {
     @GetMapping("/token")
     public ResponseEntity<Map<String, Object>> getToken(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
-            @PathVariable Long groupId) {
+            @PathVariable String groupCode) {
 
         Member member = memberService.findMemberById(memberPrincipal.id());
-        AccessToken token = liveKitService.generateToken(member, groupId);
+        AccessToken token = liveKitService.generateToken(member, groupCode);
         return ResponseEntity.ok(Map.of("token", token.toJwt()));
     }
 
@@ -63,11 +63,11 @@ public class LiveKitController2 {
     @PostMapping("/reaction")
     public ResponseEntity<Void> sendReaction(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
-            @PathVariable Long groupId,
+            @PathVariable String groupCode,
             @Valid @RequestBody LiveKitReactionRequestDto requestDto) {
 
         Member member = memberService.findMemberById(memberPrincipal.id());
-        liveKitService.sendReaction(member, groupId, requestDto.emoji());
+        liveKitService.sendReaction(member, groupCode, requestDto.emoji());
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/grit/src/main/java/grit/domain/group/livekit/service/LiveKitService.java
+++ b/backend/grit/src/main/java/grit/domain/group/livekit/service/LiveKitService.java
@@ -1,6 +1,7 @@
 package grit.domain.group.livekit.service;
 
 import grit.domain.group.GroupService;
+import grit.domain.group.entity.Group;
 import grit.domain.group.livekit.constraint.ReactionEmoji;
 import grit.domain.member.entity.Member;
 import grit.global.exception.AccessDeniedException;
@@ -41,15 +42,16 @@ public class LiveKitService {
         this.client = RoomServiceClient.createClient(url, apiKey, apiSecret);
     }
 
-    public AccessToken generateToken(Member member, Long groupId) {
-        checkPermission(member, groupId);
-        AccessToken token = new AccessToken(apiKey, apiSecret);
+    public AccessToken generateToken(Member member, String groupCode) {
+        Group group = groupService.findGroupByCode(groupCode);
+        checkPermission(member, group);
 
+        AccessToken token = new AccessToken(apiKey, apiSecret);
         token.setIdentity(member.getId().toString());
         token.setName(member.getNickname());
         token.addGrants(
                 new RoomJoin(true),
-                new RoomName(roomName(groupId)),
+                new RoomName(roomName(group.getCode())),
                 new CanPublish(true),
                 new CanSubscribe(true),
                 new CanPublishData(false)
@@ -57,9 +59,10 @@ public class LiveKitService {
         return token;
     }
 
-    public void sendReaction(Member member, Long groupId, ReactionEmoji emoji) {
-        checkPermission(member, groupId);
-        sendData(roomName(groupId),
+    public void sendReaction(Member member, String groupCode, ReactionEmoji emoji) {
+        Group group = groupService.findGroupByCode(groupCode);
+        checkPermission(member, group);
+        sendData(roomName(group.getCode()),
                 Map.of(
                         "emoji", emoji.name(),
                         "emojiChar", emoji.getEmoji(),
@@ -76,14 +79,14 @@ public class LiveKitService {
         }
     }
 
-    private void checkPermission(Member member, Long groupId) {
-        if (!groupService.isMemberInGroup(member, groupId)) {
+    private void checkPermission(Member member, Group group) {
+        if (!groupService.isMemberInGroup(member, group)) {
             throw new AccessDeniedException("권한이 없습니다.");
         }
     }
 
-    private String roomName(Long groupId) {
-        return "group:" + groupId;
+    private String roomName(String groupCode) {
+        return "group:" + groupCode;
     }
 
 }

--- a/backend/grit/src/main/java/grit/domain/group/repository/GroupRepository.java
+++ b/backend/grit/src/main/java/grit/domain/group/repository/GroupRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long>  {
-    boolean existsByInviteCode(String inviteCode); // 초대 코드 중복 체크
-    Optional<Group> findByInviteCode(String inviteCode);
+    boolean existsByCode(String code);
+    Optional<Group> findByCode(String code);
 }

--- a/backend/grit/src/main/java/grit/domain/group/repository/MemberGroupRepository.java
+++ b/backend/grit/src/main/java/grit/domain/group/repository/MemberGroupRepository.java
@@ -1,18 +1,17 @@
 package grit.domain.group.repository;
 
+import grit.domain.group.entity.Group;
 import grit.domain.group.entity.MemberGroup;
+import grit.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface MemberGroupRepository extends JpaRepository<MemberGroup, Long> {
-    // 특정 유저가 특정 그룹에 속해있는 엔티티 찾기
-    Optional<MemberGroup> findByMemberIdAndGroupId(Long memberId, Long groupId);
+    Optional<MemberGroup> findByMemberAndGroup(Member member, Group group);
 
-    // 사용자가 속해있는 모든 그룹 찾기
-    List<MemberGroup> findAllByMemberId(Long memberId);
+    List<MemberGroup> findAllByMember(Member member);
 
-    // 사용자가 그룹 멤버인지 확인
-    boolean existsByMemberIdAndGroupId(Long memberId, Long groupId);
+    boolean existsByMemberAndGroup(Member member, Group group);
 }

--- a/backend/grit/src/main/java/grit/domain/livekit/api/NewLiveKitController.java
+++ b/backend/grit/src/main/java/grit/domain/livekit/api/NewLiveKitController.java
@@ -1,6 +1,8 @@
 package grit.domain.livekit.api;
 
 import grit.domain.auth.infrastructure.jwt.MemberPrincipal;
+import grit.domain.group.GroupService;
+import grit.domain.group.entity.Group;
 import grit.domain.member.entity.Member;
 import grit.domain.member.service.MemberService;
 import io.livekit.server.AccessToken;
@@ -26,13 +28,17 @@ public class NewLiveKitController {
     private final String apiKey;
     private final String apiSecret;
     private final MemberService memberService;
+    private final GroupService groupService;
 
     public NewLiveKitController(
             @Value("${livekit.api.key}") String apiKey,
-            @Value("${livekit.api.secret}") String apiSecret, MemberService memberService) {
+            @Value("${livekit.api.secret}") String apiSecret,
+            MemberService memberService,
+            GroupService groupService) {
         this.apiKey = apiKey;
         this.apiSecret = apiSecret;
         this.memberService = memberService;
+        this.groupService = groupService;
     }
 
     @Operation(summary = "LiveKit 토큰 발급", description = "화상 회의 참여를 위한 LiveKit 액세스 토큰을 발급합니다.")
@@ -42,14 +48,15 @@ public class NewLiveKitController {
     @GetMapping("token")
     public Map<String, Object> getToken(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
-            @RequestParam Long groupId) {
+            @RequestParam String groupCode) {
 
         Member member = memberService.findMemberById(memberPrincipal.id());
+        Group group = groupService.findGroupByCode(groupCode);
 
         AccessToken token = new AccessToken(apiKey, apiSecret);
         token.setName(member.getNickname());
         token.setIdentity(member.getNickname());
-        token.addGrants(new RoomJoin(true), new RoomName(groupId.toString()));
+        token.addGrants(new RoomJoin(true), new RoomName("group:" + group.getId()));
 
         return Map.of("token", token.toJwt());
     }

--- a/backend/grit/src/main/java/grit/domain/member/controller/MemberController.java
+++ b/backend/grit/src/main/java/grit/domain/member/controller/MemberController.java
@@ -81,8 +81,7 @@ public class MemberController {
 
         Member member = getAuthenticatedMember(memberPrincipal);
         boolean isAvailable = !memberService.isNicknameTaken(member, nickname);
-        return ResponseEntity.status(isAvailable ? HttpStatus.OK : HttpStatus.CONFLICT)
-                .body(new MemberNickNameAvailabilityResponseDto(isAvailable));
+        return ResponseEntity.ok(new MemberNickNameAvailabilityResponseDto(isAvailable));
     }
 
     @Operation(summary = "회원 탈퇴", description = "사용자를 삭제(탈퇴)합니다.")

--- a/backend/grit/src/main/java/grit/domain/todo/TodoController.java
+++ b/backend/grit/src/main/java/grit/domain/todo/TodoController.java
@@ -38,17 +38,17 @@ public class TodoController {
         return ResponseEntity.ok(responses);
     }
 
-    @Operation(summary = "그룹별 투두 목록 조회", description = "특정 그룹의 투두 목록을 조회합니다.")
+    @Operation(summary = "그룹별 투두 목록 조회", description = "그룹 코드를 이용하여 특정 그룹의 투두 목록을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "403", description = "해당 그룹의 멤버가 아님", content = @Content)
     })
-    @GetMapping("/api/groups/{groupId}/todos")
+    @GetMapping("/api/groups/{groupCode}/todos")
     public ResponseEntity<List<TodoResponseDTO>> findAll(
-            @Parameter(description = "그룹 ID (PK)", example = "1") @PathVariable Long groupId,
+            @Parameter(description = "그룹 코드", example = "ABCD12") @PathVariable String groupCode,
             @Parameter(description = "사용자 ID (PK)", example = "1") @RequestParam Long userId,
             @Parameter(description = "작성자 ID (PK, 선택사항)", example = "1") @RequestParam(required = false) Long ownerId) {
-        List<Todo> todos = todoService.findAll(groupId, userId, ownerId);
+        List<Todo> todos = todoService.findAll(groupCode, userId, ownerId);
         List<TodoResponseDTO> responses = todos.stream()
                 .map(TodoResponseDTO::from)
                 .toList();

--- a/backend/grit/src/main/java/grit/domain/todo/TodoService.java
+++ b/backend/grit/src/main/java/grit/domain/todo/TodoService.java
@@ -27,15 +27,21 @@ public class TodoService {
     private final MemberRepository memberRepository;
     private final GroupRepository groupRepository;
 
-    public List<Todo> findAll(Long groupId, Long userId, Long ownerId) {
-        if (!memberGroupRepository.existsByMemberIdAndGroupId(userId, groupId)) {
+    public List<Todo> findAll(String groupCode, Long userId, Long ownerId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        Group group = groupRepository.findByCode(groupCode)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "유효하지 않은 그룹 코드입니다."));
+
+        if (!memberGroupRepository.existsByMemberAndGroup(member, group)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "해당 그룹의 멤버가 아닙니다.");
         }
 
         if (ownerId != null) {
-            return todoRepository.findByGroupIdAndOwnerIdWithRelations(groupId, ownerId);
+            return todoRepository.findByGroupIdAndOwnerIdWithRelations(group.getId(), ownerId);
         } else {
-            return todoRepository.findByGroupIdWithRelations(groupId);
+            return todoRepository.findByGroupIdWithRelations(group.getId());
         }
     }
 
@@ -55,13 +61,12 @@ public class TodoService {
         todo.setDueDate(request.getDueDate());
         todo.setIsDone(false);
 
-        if (request.getGroupId() != null) {
-            Long groupId = request.getGroupId();
-            if (!memberGroupRepository.existsByMemberIdAndGroupId(userId, groupId)) {
+        if (request.getGroupCode() != null) {
+            Group group = groupRepository.findByCode(request.getGroupCode())
+                    .orElseThrow(() -> new NoSuchElementException("유효하지 않은 그룹 코드입니다."));
+            if (!memberGroupRepository.existsByMemberAndGroup(owner, group)) {
                 throw new ResponseStatusException(HttpStatus.FORBIDDEN, "해당 그룹의 멤버가 아닙니다.");
             }
-            Group group = groupRepository.findById(groupId)
-                    .orElseThrow(() -> new NoSuchElementException("그룹을 찾을 수 없습니다."));
             todo.setGroup(group);
         }
 

--- a/backend/grit/src/main/java/grit/domain/todo/dto/CreateTodoRequestDTO.java
+++ b/backend/grit/src/main/java/grit/domain/todo/dto/CreateTodoRequestDTO.java
@@ -19,7 +19,7 @@ public class CreateTodoRequestDTO {
     @Schema(description = "마감일", example = "2025-01-25")
     private LocalDate dueDate;
 
-    @Schema(description = "그룹 ID (선택사항)", example = "1")
-    private Long groupId;
+    @Schema(description = "그룹 코드 (선택사항)", example = "ABCD12")
+    private String groupCode;
 }
 

--- a/backend/grit/src/main/java/grit/domain/todo/dto/TodoResponseDTO.java
+++ b/backend/grit/src/main/java/grit/domain/todo/dto/TodoResponseDTO.java
@@ -18,8 +18,8 @@ public class TodoResponseDTO {
     @Schema(description = "투두 고유 ID (PK)", example = "1")
     private Long id;
 
-    @Schema(description = "그룹 ID (선택사항)", example = "1")
-    private Long groupId;
+    @Schema(description = "그룹 코드 (선택사항)", example = "ABCD12")
+    private String groupCode;
 
     @Schema(description = "작성자 ID", example = "1")
     private Long ownerId;
@@ -48,7 +48,7 @@ public class TodoResponseDTO {
     public static TodoResponseDTO from(Todo todo) {
         return new TodoResponseDTO(
                 todo.getId(),
-                todo.getGroup() != null ? todo.getGroup().getId() : null,
+                todo.getGroup() != null ? todo.getGroup().getCode() : null,
                 todo.getOwner().getId(),
                 todo.getOwner().getNickname(),
                 todo.getContent(),

--- a/backend/grit/src/main/java/grit/global/util/GroupCodeGenerator.java
+++ b/backend/grit/src/main/java/grit/global/util/GroupCodeGenerator.java
@@ -2,7 +2,7 @@ package grit.global.util;
 
 import java.security.SecureRandom;
 
-public class InviteCodeGenerator {
+public class GroupCodeGenerator {
 
     // 가독성을 위해 0, O, 1, I 제외함
     private static final String CHARACTERS = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";

--- a/backend/grit/src/main/java/grit/global/util/InviteCodeGenerator.java
+++ b/backend/grit/src/main/java/grit/global/util/InviteCodeGenerator.java
@@ -5,7 +5,7 @@ import java.security.SecureRandom;
 public class InviteCodeGenerator {
 
     // 가독성을 위해 0, O, 1, I 제외함
-    private static final String CHARACTERS = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ!@*";
+    private static final String CHARACTERS = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
     private static final int CODE_LENGTH = 6;
     private static final SecureRandom random = new SecureRandom();
 

--- a/backend/grit/src/main/resources/static/groups.html
+++ b/backend/grit/src/main/resources/static/groups.html
@@ -203,7 +203,7 @@
     <div class="modal-overlay" id="edit-modal">
         <div class="modal">
             <h2>그룹 수정</h2>
-            <input type="hidden" id="edit-group-id" />
+            <input type="hidden" id="edit-group-code" />
             <div class="form-group">
                 <label for="edit-name">그룹 이름 *</label>
                 <input type="text" id="edit-name" class="form-input" placeholder="그룹 이름을 입력하세요" maxlength="30" />

--- a/backend/grit/src/main/resources/static/groups.js
+++ b/backend/grit/src/main/resources/static/groups.js
@@ -65,13 +65,13 @@ async function createGroup(name, imageName) {
     return response.json();
 }
 
-async function joinGroup(inviteCode) {
-    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/groups/join/code?inviteCode=${encodeURIComponent(inviteCode)}`, {
+async function joinGroup(groupCode) {
+    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/groups/${encodeURIComponent(groupCode)}/join`, {
         method: 'POST',
         headers: authHeaders()
     });
     if (response.status === 409) throw new Error('이미 가입된 그룹입니다.');
-    if (response.status === 404) throw new Error('존재하지 않는 초대 코드입니다.');
+    if (response.status === 404) throw new Error('존재하지 않는 그룹 코드입니다.');
     if (!response.ok) {
         const err = await response.json().catch(() => ({}));
         throw new Error(err.message || '그룹 가입에 실패했습니다.');
@@ -79,8 +79,8 @@ async function joinGroup(inviteCode) {
     return response.json();
 }
 
-async function updateGroup(groupId, name, imageName) {
-    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/groups/${groupId}`, {
+async function updateGroup(groupCode, name, imageName) {
+    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/groups/${encodeURIComponent(groupCode)}`, {
         method: 'PUT',
         headers: authHeaders(),
         body: JSON.stringify({ name, imageName: imageName || null })
@@ -93,8 +93,8 @@ async function updateGroup(groupId, name, imageName) {
     return response.json();
 }
 
-async function leaveGroup(groupId) {
-    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/groups/${groupId}`, {
+async function leaveGroup(groupCode) {
+    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/groups/${encodeURIComponent(groupCode)}`, {
         method: 'DELETE',
         headers: authHeaders()
     });
@@ -204,7 +204,7 @@ function renderGroupList(groups) {
     }
 
     container.innerHTML = groups.map(group => `
-        <div class="group-card" onclick="openDetailModal(${group.id}, '${escapeAttr(group.name)}', '${escapeAttr(group.inviteCode)}', ${group.memberCount}, '${escapeAttr(group.imageUrl || '')}')">
+        <div class="group-card" onclick="openDetailModal('${escapeAttr(group.groupCode)}', '${escapeAttr(group.name)}', ${group.memberCount}, '${escapeAttr(group.imageUrl || '')}')">
             <div class="group-card-image">
                 ${group.imageUrl
                     ? `<img src="${escapeAttr(group.imageUrl)}" alt="${escapeAttr(group.name)}" onerror="this.outerHTML='<div class=\\'group-card-placeholder\\'>${escapeHtml(group.name.charAt(0))}</div>'" />`
@@ -223,7 +223,7 @@ function renderGroupList(groups) {
                         </svg>
                         <span>${group.memberCount}명</span>
                     </div>
-                    <span class="invite-code">${escapeHtml(group.inviteCode)}</span>
+                    <span class="invite-code">${escapeHtml(group.groupCode)}</span>
                 </div>
             </div>
         </div>
@@ -352,15 +352,15 @@ document.getElementById('invite-code').addEventListener('keydown', (e) => {
 // 그룹 상세 모달
 // ────────────────────────────────────────
 
-let currentGroupId = null;
+let currentGroupCode = null;
 
-function openDetailModal(id, name, inviteCode, memberCount, imageUrl) {
-    currentGroupId = id;
+function openDetailModal(groupCode, name, memberCount, imageUrl) {
+    currentGroupCode = groupCode;
     hideError('detail-error');
 
     document.getElementById('detail-name').textContent = name;
     document.getElementById('detail-member-count').textContent = `멤버 ${memberCount}명`;
-    document.getElementById('detail-invite-code').textContent = inviteCode;
+    document.getElementById('detail-invite-code').textContent = groupCode;
 
     const imageEl = document.getElementById('detail-image');
     // Save raw image URL for Edit modal
@@ -386,7 +386,7 @@ document.getElementById('detail-leave-btn').addEventListener('click', async () =
     btn.textContent = '처리 중...';
 
     try {
-        await leaveGroup(currentGroupId);
+        await leaveGroup(currentGroupCode);
         closeModal('detail-modal');
         toast.info('그룹에서 나갔습니다.');
         await loadGroups();
@@ -410,14 +410,14 @@ document.getElementById('copy-code-btn').addEventListener('click', () => {
 
 document.getElementById('detail-video-btn').addEventListener('click', () => {
     const groupName = document.getElementById('detail-name').textContent;
-    window.location.href = `/livekit.html?groupId=${currentGroupId}&groupName=${encodeURIComponent(groupName)}`;
+    window.location.href = `/livekit.html?groupCode=${encodeURIComponent(currentGroupCode)}&groupName=${encodeURIComponent(groupName)}`;
 });
 
 document.getElementById('detail-edit-btn').addEventListener('click', () => {
     const name = document.getElementById('detail-name').textContent;
     const imageUrl = document.getElementById('detail-image').dataset.rawUrl;
     
-    document.getElementById('edit-group-id').value = currentGroupId;
+    document.getElementById('edit-group-code').value = currentGroupCode;
     document.getElementById('edit-name').value = name;
     document.getElementById('edit-image-input').value = '';
     
@@ -443,7 +443,7 @@ document.getElementById('edit-cancel-btn').addEventListener('click', () => close
 
 document.getElementById('edit-submit-btn').addEventListener('click', async () => {
     hideError('edit-error');
-    const groupId = document.getElementById('edit-group-id').value;
+    const groupCode = document.getElementById('edit-group-code').value;
     const name = document.getElementById('edit-name').value.trim();
     const imageInput = document.getElementById('edit-image-input');
 
@@ -462,7 +462,7 @@ document.getElementById('edit-submit-btn').addEventListener('click', async () =>
             imageName = await uploadGroupImage(imageInput.files[0], 'edit-image-upload');
         }
 
-        await updateGroup(groupId, name, imageName);
+        await updateGroup(groupCode, name, imageName);
         closeModal('edit-modal');
         toast.success('그룹 정보가 수정되었습니다.');
         await loadGroups();

--- a/backend/grit/src/main/resources/static/livekit.html
+++ b/backend/grit/src/main/resources/static/livekit.html
@@ -628,15 +628,15 @@
         const reactionTimers = new Map();
 
         const urlParams = new URLSearchParams(window.location.search);
-        const groupId = urlParams.get('groupId');
-        const groupName = urlParams.get('groupName') || `Group #${groupId}`;
+        const groupCode = urlParams.get('groupCode');
+        const groupName = urlParams.get('groupName') || groupCode;
 
         // ────────────────────────────────────────
         // 리액션 목록 API에서 가져오기
         // ────────────────────────────────────────
         async function fetchSupportedReactions() {
             try {
-                const res = await apiFetch(`/api/group/${groupId}/livekit/reactions`);
+                const res = await apiFetch(`/api/group/${encodeURIComponent(groupCode)}/livekit/reactions`);
                 if (!res.ok) throw new Error('리액션 목록 로드 실패');
                 const data = await res.json();
                 // API 응답: [{ name, emoji }]
@@ -656,8 +656,8 @@
                 return;
             }
 
-            if (!groupId) {
-                showOverlayError('그룹 ID가 없습니다. 그룹 페이지에서 다시 접속해주세요.');
+            if (!groupCode) {
+                showOverlayError('그룹 코드가 없습니다. 그룹 페이지에서 다시 접속해주세요.');
                 document.getElementById('join-btn').disabled = true;
                 return;
             }
@@ -712,7 +712,7 @@
             if (!room) return;
 
             try {
-                const res = await apiFetch(`/api/group/${groupId}/livekit/reaction`, {
+                const res = await apiFetch(`/api/group/${encodeURIComponent(groupCode)}/livekit/reaction`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ emoji: emojiName }),
@@ -801,7 +801,7 @@
             hideOverlayError();
 
             try {
-                const res = await apiFetch(`/api/group/${groupId}/livekit/token`);
+                const res = await apiFetch(`/api/group/${encodeURIComponent(groupCode)}/livekit/token`);
 
                 if (res.status === 401) throw new Error('인증이 만료되었습니다. 다시 로그인해주세요.');
                 if (!res.ok) throw new Error('토큰 발급에 실패했습니다.');


### PR DESCRIPTION
# 변경점 👍
- IDOR 및 resource enumeration 가능성 낮추기 위해 클라이언트에 그룹 ID 반환하지 않도록 수정
- 그룹 초대 코드에서 그룹 코드로 변경 및 관련 API 수정


# 스크린샷
- 기존
<img width="517" height="163" alt="image" src="https://github.com/user-attachments/assets/7ffc6bdd-3349-4ef5-ae2e-98ac4a5fbb77" />

- 변경 후
<img width="512" height="150" alt="image" src="https://github.com/user-attachments/assets/fd4ee7f3-6ebc-4751-abb4-d5ae2e135177" />

# 기타
- memberCount가 아닌 member list 전체 반환하도록 수정 필요할 듯

