### PR TITLE
refactor: TanStack Query 적용 및 QUERY_KEYS 상수화

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,23 +1,24 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
-import { defineConfig, globalIgnores } from 'eslint/config'
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
+import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(["dist"]),
   {
-    files: ['**/*.{ts,tsx}'],
+    files: ["**/*.{ts,tsx}"],
     extends: [
       js.configs.recommended,
       tseslint.configs.recommended,
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
+      tanstackQuery.configs.recommended,
     ],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
     },
   },
-])
+]);

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -4,6 +4,7 @@ import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 import { defineConfig, globalIgnores } from "eslint/config";
+import tanstackQuery from "@tanstack/eslint-plugin-query";
 
 export default defineConfig([
   globalIgnores(["dist"]),

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "2025grit",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.95.2",
         "axios": "^1.13.2",
         "framer-motion": "^12.34.0",
         "livekit-client": "^2.16.0",
@@ -22,6 +23,8 @@
         "@eslint/js": "^9.39.1",
         "@tailwindcss/postcss": "^4.1.17",
         "@tailwindcss/vite": "^4.1.17",
+        "@tanstack/eslint-plugin-query": "^5.95.2",
+        "@tanstack/react-query-devtools": "^5.95.2",
         "@types/node": "^24.10.0",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
@@ -1702,6 +1705,84 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.95.2.tgz",
+      "integrity": "sha512-EYUFRaqjBep4EHMPpZR12sXP7Kr5qv9iDIlq93NfbhHwhITaW6Txu3ROO6dLFz5r84T8p+oZXBG77pa2Wuok7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.48.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.95.2.tgz",
+      "integrity": "sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.95.2.tgz",
+      "integrity": "sha512-QfaoqBn9uAZ+ICkA8brd1EHj+qBF6glCFgt94U8XP5BT6ppSsDBI8IJ00BU+cAGjQzp6wcKJL2EmRYvxy0TWIg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.95.2.tgz",
+      "integrity": "sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.95.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.95.2.tgz",
+      "integrity": "sha512-AFQFmbznVkbtfpx8VJ2DylW17wWagQel/qLstVLkYmNRo2CmJt3SNej5hvl6EnEeljJIdC3BTB+W7HZtpsH+3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.95.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.95.2",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/babel__core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.95.2",
     "axios": "^1.13.2",
     "framer-motion": "^12.34.0",
     "livekit-client": "^2.16.0",
@@ -24,6 +25,8 @@
     "@eslint/js": "^9.39.1",
     "@tailwindcss/postcss": "^4.1.17",
     "@tailwindcss/vite": "^4.1.17",
+    "@tanstack/eslint-plugin-query": "^5.95.2",
+    "@tanstack/react-query-devtools": "^5.95.2",
     "@types/node": "^24.10.0",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",

--- a/frontend/src/apis/constants/queryKeys.ts
+++ b/frontend/src/apis/constants/queryKeys.ts
@@ -1,0 +1,7 @@
+export const QUERY_KEYS = {
+  groups: {
+    all: ["groups"] as const,
+    my: ["groups", "my"] as const,
+    detail: (groupCode: string) => ["groups", "detail", groupCode] as const,
+  },
+} as const;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,11 +1,18 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import "@/index.css";
 import { router } from "@/routes";
 
+const queryClient = new QueryClient();
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   </StrictMode>,
 );

--- a/frontend/src/pages/Home/components/GroupSection/GroupSection.tsx
+++ b/frontend/src/pages/Home/components/GroupSection/GroupSection.tsx
@@ -6,6 +6,7 @@ import GroupCard from "./GroupCard";
 import { groupApi } from "@/apis/services/group";
 import CreateGroupModal from "@/pages/Home/components/Modals/CreateGroupModal";
 import JoinGroupModal from "@/pages/Home/components/Modals/JoinGroupModal";
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
 
 export default function GroupSection() {
   const [isCreateGroupModalOpen, setIsCreateGroupModalOpen] = useState(false);
@@ -16,7 +17,7 @@ export default function GroupSection() {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ["groups", "my"],
+    queryKey: QUERY_KEYS.groups.my,
     queryFn: groupApi.getMyGroupList,
   });
 

--- a/frontend/src/pages/Home/components/GroupSection/GroupSection.tsx
+++ b/frontend/src/pages/Home/components/GroupSection/GroupSection.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
 import Button from "./Button";
 import GroupCard from "./GroupCard";
-import type { Group } from "@/apis/types/group";
 import { groupApi } from "@/apis/services/group";
 import CreateGroupModal from "@/pages/Home/components/Modals/CreateGroupModal";
 import JoinGroupModal from "@/pages/Home/components/Modals/JoinGroupModal";
@@ -10,20 +10,15 @@ import JoinGroupModal from "@/pages/Home/components/Modals/JoinGroupModal";
 export default function GroupSection() {
   const [isCreateGroupModalOpen, setIsCreateGroupModalOpen] = useState(false);
   const [isJoinGroupModalOpen, setIsJoinGroupModalOpen] = useState(false);
-  const [groups, setGroups] = useState<Group[]>([]);
 
-  useEffect(() => {
-    const fetchMyGroupList = async () => {
-      try {
-        const response = await groupApi.getMyGroupList();
-        setGroups(response ?? []);
-      } catch (error) {
-        console.error("내 그룹 조회 실패:", error);
-        setGroups([]);
-      }
-    };
-    fetchMyGroupList();
-  }, []);
+  const {
+    data: groups = [],
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ["groups", "my"],
+    queryFn: groupApi.getMyGroupList,
+  });
 
   return (
     <section className="w-auto h-auto bg-[#2E3039] rounded-3xl px-16 py-16">
@@ -49,15 +44,22 @@ export default function GroupSection() {
           />
         </div>
 
-        {groups.map((group) => (
-          <GroupCard
-            key={group.groupCode}
-            groupCode={group.groupCode}
-            name={group.name}
-            memberCount={group.memberCount}
-            imageUrl={group.imageUrl}
-          />
-        ))}
+        {isLoading && <div className="text-gray-300">그룹 불러오는 중...</div>}
+        {isError && (
+          <div className="text-red-400">그룹 조회에 실패했습니다.</div>
+        )}
+
+        {!isLoading &&
+          !isError &&
+          groups.map((group) => (
+            <GroupCard
+              key={group.groupCode}
+              groupCode={group.groupCode}
+              name={group.name}
+              memberCount={group.memberCount}
+              imageUrl={group.imageUrl}
+            />
+          ))}
       </div>
 
       <CreateGroupModal

--- a/frontend/src/pages/Home/components/Modals/CreateGroupModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/CreateGroupModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Copy } from "lucide-react";
 import Modal from "@/components/Modal";
 import { groupApi } from "@/apis/services/group";
@@ -17,32 +18,37 @@ export default function CreateGroupModal({
   const [groupName, setGroupName] = useState("");
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [inviteCode, setInviteCode] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
   const [copied, setCopied] = useState(false);
 
-  const handleCreateGroup = async () => {
+  const queryClient = useQueryClient();
+
+  const { mutateAsync: createNewGroup, isPending } = useMutation({
+    mutationFn: () => {
+      const trimmedGroupName = groupName.trim();
+      const defaultImageUrl =
+        "https://grit-s3.ap-northeast-2.amazonaws.com/profile/default.png";
+
+      return groupApi.create({
+        name: trimmedGroupName,
+        imageUrl: defaultImageUrl,
+      });
+    },
+    onSuccess: async (newGroup) => {
+      setInviteCode(newGroup.groupCode);
+      await queryClient.invalidateQueries({ queryKey: ["groups", "my"] });
+    },
+    onError: (error) => {
+      console.error("그룹 생성 실패", error);
+    },
+  });
+
+  const handleCreateGroup = () => {
     if (!groupName.trim()) {
       alert("그룹 이름을 입력해주세요");
       return;
     }
 
-    setIsLoading(true);
-
-    try {
-      const defaultImageUrl =
-        "https://grit-s3.ap-northeast-2.amazonaws.com/profile/default.png";
-      const response = await groupApi.create({
-        name: groupName,
-        imageUrl: defaultImageUrl,
-      });
-      setInviteCode(response.groupCode);
-      setCopied(false);
-    } catch (e) {
-      console.error("그룹 생성 실패:", e);
-      alert("그룹 생성에 실패했습니다");
-    } finally {
-      setIsLoading(false);
-    }
+    return createNewGroup();
   };
 
   const handleCopy = async () => {
@@ -91,10 +97,10 @@ export default function CreateGroupModal({
             <button
               type="button"
               onClick={handleCreateGroup}
-              disabled={isLoading || !groupName.trim()}
+              disabled={isPending || !groupName.trim()}
               className="mt-4 h-14 w-full rounded-lg bg-[#3E7358] text-lg font-semibold text-[#EDFFF4] hover:bg-emerald-800 transition disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {isLoading ? "생성 중..." : "그룹 생성하기"}
+              {isPending ? "생성 중..." : "그룹 생성하기"}
             </button>
 
             <p className="mt-6 text-center text-xs text-[#D6FDE5]">

--- a/frontend/src/pages/Home/components/Modals/CreateGroupModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/CreateGroupModal.tsx
@@ -4,6 +4,7 @@ import { Copy } from "lucide-react";
 import Modal from "@/components/Modal";
 import { groupApi } from "@/apis/services/group";
 import { ImageUploader } from "@/components/ImageUploader";
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
 
 type CreateGroupModalProps = {
   open: boolean;
@@ -14,7 +15,6 @@ export default function CreateGroupModal({
   open,
   onClose,
 }: CreateGroupModalProps) {
-  //group input 값
   const [groupName, setGroupName] = useState("");
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [inviteCode, setInviteCode] = useState("");
@@ -35,7 +35,7 @@ export default function CreateGroupModal({
     },
     onSuccess: async (newGroup) => {
       setInviteCode(newGroup.groupCode);
-      await queryClient.invalidateQueries({ queryKey: ["groups", "my"] });
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.groups.my });
     },
     onError: (error) => {
       console.error("그룹 생성 실패", error);

--- a/frontend/src/pages/Home/components/Modals/GroupSettingsModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/GroupSettingsModal.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import Modal from "@/components/Modal";
 import { groupApi } from "@/apis/services/group";
 import { ImageUploader } from "@/components/ImageUploader";
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
 
 type GroupSettingsModalProps = {
   open: boolean;
@@ -25,7 +26,7 @@ export default function GroupSettingsModal({
   const [imageFile, setImageFile] = useState<File | null>(null);
 
   const { data: groupInfo, isLoading: isGroupDetailLoading } = useQuery({
-    queryKey: ["groups", "detail", groupCode],
+    queryKey: QUERY_KEYS.groups.detail(groupCode),
     queryFn: () => groupApi.getMyGroup(groupCode),
     enabled: open && !!groupCode,
   });
@@ -37,7 +38,7 @@ export default function GroupSettingsModal({
     setBaseGroupImage(groupInfo.imageUrl ?? "");
     setGroupName(groupInfo.name);
     setImageFile(null);
-  }, [open, groupCode]);
+  }, [open, groupInfo]);
 
   const handleClose = () => {
     setGroupName(baseGroupName);
@@ -59,9 +60,11 @@ export default function GroupSettingsModal({
         }),
       onSuccess: async () => {
         await queryClient.invalidateQueries({
-          queryKey: ["groups", "detail", groupCode],
+          queryKey: QUERY_KEYS.groups.detail(groupCode),
         });
-        await queryClient.invalidateQueries({ queryKey: ["groups", "my"] });
+        await queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.groups.my,
+        });
         handleClose();
       },
       onError: (error) => {

--- a/frontend/src/pages/Home/components/Modals/GroupSettingsModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/GroupSettingsModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import Modal from "@/components/Modal";
 import { groupApi } from "@/apis/services/group";
 import { ImageUploader } from "@/components/ImageUploader";
@@ -22,51 +23,58 @@ export default function GroupSettingsModal({
   const [baseGroupImage, setBaseGroupImage] = useState(initialImage);
   const [groupName, setGroupName] = useState(initialName);
   const [imageFile, setImageFile] = useState<File | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+
+  const { data: groupInfo, isLoading: isGroupDetailLoading } = useQuery({
+    queryKey: ["groups", "detail", groupCode],
+    queryFn: () => groupApi.getMyGroup(groupCode),
+    enabled: open && !!groupCode,
+  });
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || !groupInfo) return;
 
-    const fetchGroupDetail = async () => {
-      try {
-        const groupInfo = await groupApi.getMyGroup(groupCode);
-        setBaseGroupName(groupInfo.name);
-        setBaseGroupImage(groupInfo.imageUrl);
-        setGroupName(groupInfo.name);
-        setImageFile(null);
-      } catch (error) {
-        console.error("그룹 상세 조회 에러", error);
-      }
-    };
-
-    fetchGroupDetail();
+    setBaseGroupName(groupInfo.name);
+    setBaseGroupImage(groupInfo.imageUrl ?? "");
+    setGroupName(groupInfo.name);
+    setImageFile(null);
   }, [open, groupCode]);
 
   const handleClose = () => {
     setGroupName(baseGroupName);
     setImageFile(null);
-    setIsLoading(false);
     onClose();
   };
 
-  const handleSave = async () => {
-    if (!groupName.trim()) return;
+  const queryClient = useQueryClient();
 
-    setIsLoading(true);
-    try {
-      await groupApi.update(groupCode, {
-        name: groupName.trim(),
-        imageUrl: imageFile
-          ? "업로드된_URL"
-          : baseGroupImage ||
-            "https://grit-s3.ap-northeast-2.amazonaws.com/profile/default.png",
-      });
-      handleClose();
-    } catch (error) {
-      console.error("그룹 정보 수정 실패:", error);
-    } finally {
-      setIsLoading(false);
+  const { mutateAsync: updateGroup, isPending: isGroupInfoSaving } =
+    useMutation({
+      mutationFn: () =>
+        groupApi.update(groupCode, {
+          name: groupName.trim(),
+          imageUrl: imageFile
+            ? "업로드된_URL"
+            : baseGroupImage ||
+              "https://grit-s3.ap-northeast-2.amazonaws.com/profile/default.png",
+        }),
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: ["groups", "detail", groupCode],
+        });
+        await queryClient.invalidateQueries({ queryKey: ["groups", "my"] });
+        handleClose();
+      },
+      onError: (error) => {
+        console.error("그룹 정보 수정 실패:", error);
+      },
+    });
+
+  const handleSave = async () => {
+    if (!groupName.trim()) {
+      alert("그룹 이름을 입력해주세요.");
+      return;
     }
+    await updateGroup();
   };
 
   return (
@@ -102,10 +110,10 @@ export default function GroupSettingsModal({
             <button
               type="button"
               onClick={handleSave}
-              disabled={isLoading}
+              disabled={isGroupDetailLoading}
               className="mt-4 h-14 w-full rounded-lg bg-[#3E7358] text-lg font-semibold text-[#EDFFF4] hover:bg-emerald-800 transition disabled:opacity-50"
             >
-              {isLoading ? "저장 중..." : "그룹 정보 저장하기"}
+              {isGroupInfoSaving ? "저장 중..." : "그룹 정보 저장하기"}
             </button>
 
             <p className="mt-6 text-center text-xs text-[#D6FDE5]">

--- a/frontend/src/pages/Home/components/Modals/GroupSettingsModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/GroupSettingsModal.tsx
@@ -25,7 +25,7 @@ export default function GroupSettingsModal({
   const [groupName, setGroupName] = useState(initialName);
   const [imageFile, setImageFile] = useState<File | null>(null);
 
-  const { data: groupInfo, isLoading: isGroupDetailLoading } = useQuery({
+  const { data: groupInfo } = useQuery({
     queryKey: QUERY_KEYS.groups.detail(groupCode),
     queryFn: () => groupApi.getMyGroup(groupCode),
     enabled: open && !!groupCode,
@@ -113,7 +113,7 @@ export default function GroupSettingsModal({
             <button
               type="button"
               onClick={handleSave}
-              disabled={isGroupDetailLoading}
+              disabled={isGroupInfoSaving}
               className="mt-4 h-14 w-full rounded-lg bg-[#3E7358] text-lg font-semibold text-[#EDFFF4] hover:bg-emerald-800 transition disabled:opacity-50"
             >
               {isGroupInfoSaving ? "저장 중..." : "그룹 정보 저장하기"}

--- a/frontend/src/pages/Home/components/Modals/JoinGroupModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/JoinGroupModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import Modal from "@/components/Modal";
 import { groupApi } from "@/apis/services/group";
 
@@ -9,27 +10,26 @@ type JoinGroupModalProps = {
 
 export default function JoinGroupModal({ open, onClose }: JoinGroupModalProps) {
   const [inviteCode, setInviteCode] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
+  const queryClient = useQueryClient();
+
+  const { mutateAsync: joinGroup, isPending } = useMutation({
+    mutationFn: (groupCode: string) => groupApi.join(groupCode),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["groups", "my"] });
+      setInviteCode("");
+      onClose();
+    },
+    onError: (error) => {
+      console.log("그룹 참여 실패", error);
+    },
+  });
 
   const handleJoinNewGroup = async () => {
     const groupCode = inviteCode.trim();
-
     if (!groupCode) {
-      alert("초대 코드 입력 요망");
       return;
     }
-
-    setIsLoading(true);
-    try {
-      await groupApi.join(groupCode);
-      setInviteCode("");
-      onClose();
-    } catch (error) {
-      console.log("그룹 참여 실패", error);
-      alert("그룹 참여 실패");
-    } finally {
-      setIsLoading(false);
-    }
+    await joinGroup(groupCode);
   };
 
   return (
@@ -53,17 +53,17 @@ export default function JoinGroupModal({ open, onClose }: JoinGroupModalProps) {
               className="h-14 w-full rounded-xl bg-white px-6 text-lg text-gray-900 outline-none"
               aria-label="초대 코드"
               placeholder="초대 코드를 입력하세요"
-              disabled={isLoading}
+              disabled={isPending}
             />
           </div>
 
           <button
             type="button"
             onClick={handleJoinNewGroup}
-            disabled={isLoading || !inviteCode.trim()}
+            disabled={isPending || !inviteCode.trim()}
             className="mt-4 h-14 w-full max-w-[360px] rounded-xl bg-[#3E7358] text-lg font-semibold text-white hover:bg-emerald-800 transition disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {isLoading ? "참여 중..." : "참여하기"}
+            {isPending ? "참여 중..." : "참여하기"}
           </button>
         </Modal.Body>
       </Modal.Content>

--- a/frontend/src/pages/Home/components/Modals/JoinGroupModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/JoinGroupModal.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import Modal from "@/components/Modal";
 import { groupApi } from "@/apis/services/group";
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
 
 type JoinGroupModalProps = {
   open: boolean;
@@ -15,7 +16,7 @@ export default function JoinGroupModal({ open, onClose }: JoinGroupModalProps) {
   const { mutateAsync: joinGroup, isPending } = useMutation({
     mutationFn: (groupCode: string) => groupApi.join(groupCode),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["groups", "my"] });
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.groups.my });
       setInviteCode("");
       onClose();
     },


### PR DESCRIPTION
## 변경점
- TanStack Query를 통한 그룹 관련 API 호출 로직 리팩토링하였습니다.
- 기존 useEffect + isLoading state 패턴을 Query 상태 중심으로 리팩토링하였습니다.

## 개선점
- 그룹 관련 쿼리 키를 QUERY_KEYS 상수로 분리해 하드코딩 문자열 제거하였습니다.
- mutation 성공 시 `invalidateQueries`를 통해 그룹 목록이 새로고침 없이 최신 상태로 반영되도록 구현하였습니다.

## 테스트
- [x] 초대 코드 입력 후 참여 시 그룹 목록이 새로고침 없이 갱신되는지 확인
- [x] 그룹 생성 후 그룹 목록이 새로고침 없이 갱신되는지 확인
- [x] 그룹 정보 수정 후 상세/목록 캐시가 무효화되어 최신 값이 반영되는지 확인