### PR TITLE
refactor: ENDPOINTS 구조 개선

### DIFF
--- a/frontend/src/apis/client/apiClient.ts
+++ b/frontend/src/apis/client/apiClient.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { API_BASE_URL } from "@/apis/constants/endpoints";
 import { PATHS } from "@/routes/path";
-import { API_ENDPOINTS } from "@/apis/constants/endpoints";
+import { ENDPOINTS } from "@/apis/constants/endpoints";
 
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,
@@ -54,7 +54,7 @@ apiClient.interceptors.response.use(
     if (
       error.response?.status === 401 &&
       !originalRequest._retry &&
-      originalRequest.url !== API_ENDPOINTS.AUTH.REFRESH
+      originalRequest.url !== ENDPOINTS.AUTH.REFRESH
     ) {
       if (isRefreshingToken) {
         return new Promise((resolve) => {
@@ -70,7 +70,7 @@ apiClient.interceptors.response.use(
 
       try {
         const refreshResponse = await axios.post(
-          `${API_BASE_URL}${API_ENDPOINTS.AUTH.REFRESH}`,
+          `${API_BASE_URL}${ENDPOINTS.AUTH.REFRESH}`,
           {},
           { withCredentials: true },
         );

--- a/frontend/src/apis/constants/endpoints.ts
+++ b/frontend/src/apis/constants/endpoints.ts
@@ -19,7 +19,6 @@ export const ENDPOINTS = {
     IMAGE_UPLOAD: "/api/groups/image-upload-url",
   },
   LIVEKIT: {
-    URL: import.meta.env.VITE_LIVEKIT_URL,
     TOKEN: "/livekit/token",
   },
 } as const;

--- a/frontend/src/apis/constants/endpoints.ts
+++ b/frontend/src/apis/constants/endpoints.ts
@@ -1,18 +1,22 @@
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 export const LIVEKIT_URL = import.meta.env.VITE_LIVEKIT_URL;
 
-export const API_ENDPOINTS = {
+export const ENDPOINTS = {
   AUTH: {
     GOOGLE: "/api/auth/google",
     REFRESH: "/api/auth/refresh",
     LOGOUT: "/api/auth/logout",
+  },
+  MY: {
     INFO: "/api/members/me",
+    IMAGE_UPLOAD: `/api/members/me/profile-image/upload-url`,
   },
   GROUP: {
     CREATE: "/api/groups",
     MY: "/api/groups/my",
-    DETAIL: (groupCode: string) => `/api/groups/${groupCode}`,
+    INFO: (groupCode: string) => `/api/groups/${groupCode}`,
     JOIN: (groupCode: string) => `/api/groups/${groupCode}/join`,
+    IMAGE_UPLOAD: "/api/groups/image-upload-url",
   },
   LIVEKIT: {
     URL: import.meta.env.VITE_LIVEKIT_URL,

--- a/frontend/src/apis/services/auth.ts
+++ b/frontend/src/apis/services/auth.ts
@@ -1,12 +1,10 @@
 import apiClient from "@/apis/client/apiClient";
-
 import type {
   GoogleLoginRequest,
   GoogleLoginResponse,
-  Member,
 } from "@/apis/types/auth";
 import { OAUTH_CONFIG } from "@/apis/constants/oauth";
-import { API_ENDPOINTS } from "@/apis/constants/endpoints";
+import { ENDPOINTS } from "@/apis/constants/endpoints";
 import type { RefreshTokenResponse } from "@/apis/types/auth";
 
 export const loginGoogle = async (
@@ -17,7 +15,7 @@ export const loginGoogle = async (
     redirectUri: OAUTH_CONFIG.GOOGLE.REDIRECT_URI,
   };
   const response = await apiClient.post<GoogleLoginResponse>(
-    API_ENDPOINTS.AUTH.GOOGLE,
+    ENDPOINTS.AUTH.GOOGLE,
     requestBody,
     { withCredentials: true },
   );
@@ -40,7 +38,7 @@ export const loginGoogle = async (
 
 export const refreshAccessToken = async (): Promise<string> => {
   const response = await apiClient.post<RefreshTokenResponse>(
-    API_ENDPOINTS.AUTH.REFRESH,
+    ENDPOINTS.AUTH.REFRESH,
     {},
     { withCredentials: true },
   );
@@ -55,19 +53,14 @@ export const refreshAccessToken = async (): Promise<string> => {
   return accessToken;
 };
 
-export const getUserInfo = async (): Promise<Member> => {
-  const response = await apiClient.get<Member>(API_ENDPOINTS.AUTH.INFO);
-  return response.data;
-};
-
 export const logout = async (): Promise<void> => {
-  await apiClient.post(API_ENDPOINTS.AUTH.LOGOUT, {
+  await apiClient.post(ENDPOINTS.AUTH.LOGOUT, {
     withCredentials: true,
   });
   localStorage.removeItem("auth-storage");
 };
 
 export const signout = async (): Promise<void> => {
-  await apiClient.delete(API_ENDPOINTS.AUTH.INFO);
+  await apiClient.delete(ENDPOINTS.MY.INFO);
   localStorage.removeItem("auth-storage");
 };

--- a/frontend/src/apis/services/group.ts
+++ b/frontend/src/apis/services/group.ts
@@ -1,5 +1,5 @@
 import apiClient from "@/apis/client/apiClient";
-import { API_ENDPOINTS } from "@/apis/constants/endpoints";
+import { ENDPOINTS } from "@/apis/constants/endpoints";
 import type {
   CreateGroupRequest,
   UpdateGroupRequest,
@@ -8,28 +8,25 @@ import type {
 
 export const groupApi = {
   create: async (data: CreateGroupRequest): Promise<Group> => {
-    const response = await apiClient.post<Group>(
-      API_ENDPOINTS.GROUP.CREATE,
-      data,
-    );
+    const response = await apiClient.post<Group>(ENDPOINTS.GROUP.CREATE, data);
     return response.data;
   },
 
   getMyGroup: async (groupCode: string) => {
     const response = await apiClient.get<Group>(
-      API_ENDPOINTS.GROUP.DETAIL(groupCode),
+      ENDPOINTS.GROUP.INFO(groupCode),
     );
     return response.data;
   },
 
   getMyGroupList: async () => {
-    const response = await apiClient.get<Group[]>(API_ENDPOINTS.GROUP.MY);
+    const response = await apiClient.get<Group[]>(ENDPOINTS.GROUP.MY);
     return response.data;
   },
 
   join: async (groupCode: string) => {
     const response = await apiClient.post<Group>(
-      API_ENDPOINTS.GROUP.JOIN(groupCode),
+      ENDPOINTS.GROUP.JOIN(groupCode),
     );
     return response.data;
   },
@@ -39,7 +36,7 @@ export const groupApi = {
     data: UpdateGroupRequest,
   ): Promise<Group> => {
     const response = await apiClient.put<Group>(
-      API_ENDPOINTS.GROUP.DETAIL(groupCode),
+      ENDPOINTS.GROUP.INFO(groupCode),
       data,
     );
     return response.data;

--- a/frontend/src/apis/services/livekit.ts
+++ b/frontend/src/apis/services/livekit.ts
@@ -1,16 +1,13 @@
 import apiClient from "@/apis/client/apiClient";
 import type { TokenResponse } from "@/apis/types/livekit";
-import { API_ENDPOINTS } from "@/apis/constants/endpoints";
+import { ENDPOINTS } from "@/apis/constants/endpoints";
 
 export const getLiveKitToken = async (
   room: string,
   user: string,
 ): Promise<string> => {
-  const response = await apiClient.get<TokenResponse>(
-    API_ENDPOINTS.LIVEKIT.TOKEN,
-    {
-      params: { room, user },
-    },
-  );
+  const response = await apiClient.get<TokenResponse>(ENDPOINTS.LIVEKIT.TOKEN, {
+    params: { room, user },
+  });
   return response.data.token;
 };

--- a/frontend/src/apis/services/my.ts
+++ b/frontend/src/apis/services/my.ts
@@ -1,0 +1,8 @@
+import apiClient from "@/apis/client/apiClient";
+import type { Member } from "@/apis/types/auth";
+import { ENDPOINTS } from "@/apis/constants/endpoints";
+
+export const getUserInfo = async (): Promise<Member> => {
+  const response = await apiClient.get<Member>(ENDPOINTS.MY.INFO);
+  return response.data;
+};

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -3,7 +3,8 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { PATHS } from "@/routes/path";
 import type { Member } from "@/apis/types";
-import { getUserInfo, logout, signout } from "@/apis/services/auth";
+import { logout, signout } from "@/apis/services/auth";
+import { getUserInfo } from "@/apis/services/my";
 
 type HeaderProps = {
   variant: "light" | "dark";
@@ -16,7 +17,7 @@ export function Header({ variant, alwaysVisible = false }: HeaderProps) {
   const navigate = useNavigate();
   const [user, setUser] = useState<Member | null>(null);
 
-useEffect(() => {
+  useEffect(() => {
     let mounted = true;
     const fetchUser = async () => {
       try {


### PR DESCRIPTION
## 변경점 
- ENDPOINTS를 도메인별로 정리하였습니다.
- AUTH에서 MY를 분리하였습니다.
- LIVEKIT URL의 중복 상수를 제거하였습니다.

## 테스트
- [x] `npm run build` 성공 확인