### PR TITLE
Feat: 그룹 이미지 presigned URL S3 업로드 연동

### DIFF
--- a/frontend/src/apis/services/group.ts
+++ b/frontend/src/apis/services/group.ts
@@ -1,9 +1,11 @@
+import axios from "axios";
 import apiClient from "@/apis/client/apiClient";
 import { ENDPOINTS } from "@/apis/constants/endpoints";
 import type {
   CreateGroupRequest,
   UpdateGroupRequest,
   Group,
+  S3uploadResponse,
 } from "@/apis/types";
 
 export const groupApi = {
@@ -12,19 +14,19 @@ export const groupApi = {
     return response.data;
   },
 
-  getMyGroup: async (groupCode: string) => {
+  getMyGroup: async (groupCode: string): Promise<Group> => {
     const response = await apiClient.get<Group>(
       ENDPOINTS.GROUP.INFO(groupCode),
     );
     return response.data;
   },
 
-  getMyGroupList: async () => {
+  getMyGroupList: async (): Promise<Group[]> => {
     const response = await apiClient.get<Group[]>(ENDPOINTS.GROUP.MY);
     return response.data;
   },
 
-  join: async (groupCode: string) => {
+  join: async (groupCode: string): Promise<Group> => {
     const response = await apiClient.post<Group>(
       ENDPOINTS.GROUP.JOIN(groupCode),
     );
@@ -40,5 +42,21 @@ export const groupApi = {
       data,
     );
     return response.data;
+  },
+
+  imageUpload: async (): Promise<S3uploadResponse> => {
+    const response = await apiClient.get<S3uploadResponse>(
+      ENDPOINTS.GROUP.IMAGE_UPLOAD,
+    );
+    return response.data;
+  },
+
+  putImage: async (uploadUrl: string, file: globalThis.File): Promise<void> => {
+    const contentType = file.type;
+    await axios.put(uploadUrl, file, {
+      headers: {
+        "Content-Type": contentType,
+      },
+    });
   },
 } as const;

--- a/frontend/src/apis/services/group.ts
+++ b/frontend/src/apis/services/group.ts
@@ -44,19 +44,25 @@ export const groupApi = {
     return response.data;
   },
 
-  imageUpload: async (): Promise<S3uploadResponse> => {
+  getPresignedUploadInfo: async (): Promise<S3uploadResponse> => {
     const response = await apiClient.get<S3uploadResponse>(
       ENDPOINTS.GROUP.IMAGE_UPLOAD,
     );
     return response.data;
   },
 
-  putImage: async (uploadUrl: string, file: globalThis.File): Promise<void> => {
+  putImageToS3: async (uploadUrl: string, file: File): Promise<void> => {
     const contentType = file.type;
     await axios.put(uploadUrl, file, {
       headers: {
         "Content-Type": contentType,
       },
     });
+  },
+
+  uploadImage: async (file: File): Promise<string> => {
+    const { uploadUrl, fileName } = await groupApi.getPresignedUploadInfo();
+    await groupApi.putImageToS3(uploadUrl, file);
+    return fileName;
   },
 } as const;

--- a/frontend/src/apis/types/auth.ts
+++ b/frontend/src/apis/types/auth.ts
@@ -1,4 +1,3 @@
-//구글 로그인
 export interface Member {
   id: number;
   nickname: string;
@@ -19,7 +18,6 @@ export interface GoogleLoginResponse {
   firstTimeUser: boolean;
 }
 
-//토큰
 export interface RefreshTokenResponse {
   accessToken: string;
 }

--- a/frontend/src/apis/types/group.ts
+++ b/frontend/src/apis/types/group.ts
@@ -2,12 +2,17 @@ export interface Group {
   groupCode: string;
   name: string;
   memberCount: number;
-  imageUrl: string;
+  imageUrl: string; //get 응답에서 받는 랜더링을 위한 URL
 }
 
 export interface GroupInput {
   name: string;
-  imageUrl: string;
+  imageName?: string; //create 또는 update 시에 서버로 보내는 값
+}
+
+export interface S3uploadResponse {
+  fileName: string; //백엔드가 준 키 = UUID
+  uploadUrl: string; //S3에 put할 주소 = Presigned URL
 }
 
 export type CreateGroupRequest = GroupInput;

--- a/frontend/src/apis/types/index.ts
+++ b/frontend/src/apis/types/index.ts
@@ -1,2 +1,3 @@
 export * from "@/apis/types/group";
 export * from "@/apis/types/auth";
+export * from "@/apis/types/livekit";

--- a/frontend/src/pages/Home/components/GroupSection/GroupCard.tsx
+++ b/frontend/src/pages/Home/components/GroupSection/GroupCard.tsx
@@ -58,7 +58,7 @@ export default function GroupCard({
         onClose={() => setIsSettingsOpen(false)}
         groupCode={groupCode}
         initialName={name}
-        initialImage={imageUrl}
+        initialImage={imageName}
       />
     </div>
   );

--- a/frontend/src/pages/Home/components/GroupSection/GroupCard.tsx
+++ b/frontend/src/pages/Home/components/GroupSection/GroupCard.tsx
@@ -58,7 +58,7 @@ export default function GroupCard({
         onClose={() => setIsSettingsOpen(false)}
         groupCode={groupCode}
         initialName={name}
-        initialImage={imageName}
+        initialImage={imageUrl}
       />
     </div>
   );

--- a/frontend/src/pages/Home/components/Modals/CreateGroupModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/CreateGroupModal.tsx
@@ -27,12 +27,11 @@ export default function CreateGroupModal({
       const trimmedGroupName = groupName.trim();
 
       if (imageFile) {
-        const { uploadUrl, fileName } = await groupApi.imageUpload();
-        await groupApi.putImage(uploadUrl, imageFile);
+        const imageName = await groupApi.uploadImage(imageFile);
 
         return groupApi.create({
           name: trimmedGroupName,
-          imageName: fileName,
+          imageName,
         });
       }
 

--- a/frontend/src/pages/Home/components/Modals/CreateGroupModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/CreateGroupModal.tsx
@@ -18,19 +18,26 @@ export default function CreateGroupModal({
   const [groupName, setGroupName] = useState("");
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [inviteCode, setInviteCode] = useState("");
-  const [copied, setCopied] = useState(false);
+  const [_, setCopied] = useState(false);
 
   const queryClient = useQueryClient();
 
   const { mutateAsync: createNewGroup, isPending } = useMutation({
-    mutationFn: () => {
+    mutationFn: async () => {
       const trimmedGroupName = groupName.trim();
-      const defaultImageUrl =
-        "https://grit-s3.ap-northeast-2.amazonaws.com/profile/default.png";
+
+      if (imageFile) {
+        const { uploadUrl, fileName } = await groupApi.imageUpload();
+        await groupApi.putImage(uploadUrl, imageFile);
+
+        return groupApi.create({
+          name: trimmedGroupName,
+          imageName: fileName,
+        });
+      }
 
       return groupApi.create({
         name: trimmedGroupName,
-        imageUrl: defaultImageUrl,
       });
     },
     onSuccess: async (newGroup) => {

--- a/frontend/src/pages/Home/components/Modals/GroupSettingsModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/GroupSettingsModal.tsx
@@ -50,14 +50,22 @@ export default function GroupSettingsModal({
 
   const { mutateAsync: updateGroup, isPending: isGroupInfoSaving } =
     useMutation({
-      mutationFn: () =>
-        groupApi.update(groupCode, {
-          name: groupName.trim(),
-          imageUrl: imageFile
-            ? "업로드된_URL"
-            : baseGroupImage ||
-              "https://grit-s3.ap-northeast-2.amazonaws.com/profile/default.png",
-        }),
+      mutationFn: async () => {
+        const trimmedGroupName = groupName.trim();
+        if (imageFile) {
+          const { uploadUrl, fileName } = await groupApi.imageUpload();
+          await groupApi.putImage(uploadUrl, imageFile);
+
+          return await groupApi.update(groupCode, {
+            name: trimmedGroupName,
+            imageName: fileName,
+          });
+        }
+        return groupApi.update(groupCode, {
+          name: trimmedGroupName,
+        });
+      },
+
       onSuccess: async () => {
         await queryClient.invalidateQueries({
           queryKey: QUERY_KEYS.groups.detail(groupCode),
@@ -67,6 +75,7 @@ export default function GroupSettingsModal({
         });
         handleClose();
       },
+
       onError: (error) => {
         console.error("그룹 정보 수정 실패:", error);
       },

--- a/frontend/src/pages/Home/components/Modals/GroupSettingsModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/GroupSettingsModal.tsx
@@ -53,12 +53,11 @@ export default function GroupSettingsModal({
       mutationFn: async () => {
         const trimmedGroupName = groupName.trim();
         if (imageFile) {
-          const { uploadUrl, fileName } = await groupApi.imageUpload();
-          await groupApi.putImage(uploadUrl, imageFile);
+          const imageName = await groupApi.uploadImage(imageFile);
 
-          return await groupApi.update(groupCode, {
+          return groupApi.update(groupCode, {
             name: trimmedGroupName,
-            imageName: fileName,
+            imageName,
           });
         }
         return groupApi.update(groupCode, {


### PR DESCRIPTION
## 변경점
- 그룹 이미지 업로드를 presigned URL 기반으로 변경/연동했습니다.
  - GET /api/groups/image-upload-url로 uploadUrl + fileName `fileName=UUID key`을 발급받는다
  - PUT uploadUrl로 사용자가 선택한 이미지 파일을 S3에 업로드한다,
  - create/update 요청에는 imageName: fileName `명세의 fileName`을 전달하도록 연결했습니다.
- 업로드 PUT 시 Content-Type은 `file.type`을 사용해 파일 MIME 타입이 맞게 전송되도록 했습니다.
- ENDPOINTS에 그룹 이미지 업로드 URL 발급 엔드포인트 추가
  ```
  imageUpload() : presigned URL 발급(GET)
  putImage(uploadUrl, file) : S3에 직접 PUT(바이너리 업로드)
  ```
- `CreateGroupModal` `GroupSettingsModal` 적용

  ```
  그룹 생성 전 업로드 단계(발급 이후 PUT)를 먼저 수행하고, 생성 API에 imageName 전달
  ```

## 개선점
- `CreateGroupModal.tsx`와 `GroupSettingsModal.tsx`에서 반복되고 있는 이미지 업로드 로직을 groupApi 레이어로 분리하였습니다.
  ```
  //변경후
  async uploadImage(file: File): Promise<string> {
    const { uploadUrl, fileName } = await this.imageUpload();
    await this.putImage(uploadUrl, file);
    return fileName;
  }
  ```
  
  ```
  //변경후
  if (imageFile) {
    imageName = await groupApi.uploadImage(imageFile);
  }
  
  ```
  - 기대 효과 : 업로드 로직의 재사용성을 높였으며 컴포넌트는 UI와 흐름에만 집중할 수 있으고 추후 업로드 방식 변경 시 수정 범위를 최소화할 수 있습니다.

## 테스트
<img width="492" height="102" alt="스크린샷 2026-03-25 오후 5 00 23" src="https://github.com/user-attachments/assets/76da3a3d-3034-4469-bc37-1561b0700950" />
<img width="663" height="337" alt="스크린샷 2026-03-25 오후 5 00 10" src="https://github.com/user-attachments/assets/446330c0-b5d9-4bcd-a7b3-3d02c58649b0" />
