### PR TITLE
feat: 친구 목록 조회, 친구 추가, 친구 삭제 api 연동

### DIFF
--- a/frontend/src/apis/constants/endpoints.ts
+++ b/frontend/src/apis/constants/endpoints.ts
@@ -20,6 +20,10 @@ export const ENDPOINTS = {
     JOIN: (groupCode: string) => `/api/groups/${groupCode}/join`,
     IMAGE_UPLOAD: "/api/groups/image-upload-url",
   },
+  FRIEND: {
+    LIST: "/api/friends",
+    DETAIL: (nickname: string) => `/api/friends/${nickname}`,
+  },
   LIVEKIT: {
     TOKEN: "/livekit/token",
   },

--- a/frontend/src/apis/constants/queryKeys.ts
+++ b/frontend/src/apis/constants/queryKeys.ts
@@ -7,4 +7,7 @@ export const QUERY_KEYS = {
     my: ["groups", "my"] as const,
     detail: (groupCode: string) => ["groups", "detail", groupCode] as const,
   },
+  friend: {
+    all: ["friends"] as const,
+  },
 } as const;

--- a/frontend/src/apis/services/friend.ts
+++ b/frontend/src/apis/services/friend.ts
@@ -2,7 +2,7 @@ import apiClient from "@/apis/client/apiClient";
 import { ENDPOINTS } from "@/apis/constants/endpoints";
 import type { Friend, FriendListResponse } from "@/apis/types/friend";
 
-export const FriendApi = {
+export const friendApi = {
   getList: async (): Promise<FriendListResponse[]> => {
     const response = await apiClient.get<FriendListResponse[]>(
       ENDPOINTS.FRIEND.LIST,

--- a/frontend/src/apis/services/friend.ts
+++ b/frontend/src/apis/services/friend.ts
@@ -1,0 +1,21 @@
+import apiClient from "@/apis/client/apiClient";
+import { ENDPOINTS } from "@/apis/constants/endpoints";
+import type { Friend, FriendListResponse } from "@/apis/types/friend";
+
+export const FriendApi = {
+  getList: async (): Promise<FriendListResponse[]> => {
+    const response = await apiClient.get<FriendListResponse[]>(
+      ENDPOINTS.FRIEND.LIST,
+    );
+    return response.data;
+  },
+  addFriend: async (nickname: string): Promise<Friend> => {
+    const response = await apiClient.post<Friend>(
+      ENDPOINTS.FRIEND.DETAIL(nickname),
+    );
+    return response.data;
+  },
+  removeFriend: async (nickname: string): Promise<void> => {
+    await apiClient.delete(ENDPOINTS.FRIEND.DETAIL(nickname));
+  },
+};

--- a/frontend/src/apis/services/friend.ts
+++ b/frontend/src/apis/services/friend.ts
@@ -1,16 +1,14 @@
 import apiClient from "@/apis/client/apiClient";
 import { ENDPOINTS } from "@/apis/constants/endpoints";
-import type { Friend, FriendListResponse } from "@/apis/types/friend";
+import type { FriendDetail } from "@/apis/types/friend";
 
 export const friendApi = {
-  getList: async (): Promise<FriendListResponse[]> => {
-    const response = await apiClient.get<FriendListResponse[]>(
-      ENDPOINTS.FRIEND.LIST,
-    );
+  getList: async (): Promise<FriendDetail[]> => {
+    const response = await apiClient.get<FriendDetail[]>(ENDPOINTS.FRIEND.LIST);
     return response.data;
   },
-  addFriend: async (nickname: string): Promise<Friend> => {
-    const response = await apiClient.post<Friend>(
+  addFriend: async (nickname: string): Promise<FriendDetail> => {
+    const response = await apiClient.post<FriendDetail>(
       ENDPOINTS.FRIEND.DETAIL(nickname),
     );
     return response.data;

--- a/frontend/src/apis/types/friend.ts
+++ b/frontend/src/apis/types/friend.ts
@@ -1,0 +1,18 @@
+export interface Friend {
+  friendId: number;
+  nickname: string;
+  introduction: string;
+}
+
+export interface FriendDetail {
+  nickname: string;
+  introduction: string;
+  imageUrl: string;
+  dDayDate: string;
+  dDayTitle: string;
+  weeklyStudyTimeGoal: string;
+}
+
+export interface FriendListResponse {
+  data: FriendDetail[];
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -10,9 +10,14 @@ import { QUERY_KEYS } from "@/apis/constants/queryKeys";
 type HeaderProps = {
   variant: "light" | "dark";
   alwaysVisible?: boolean;
+  onOpenFriendManage?: () => void;
 };
 
-export function Header({ variant, alwaysVisible = false }: HeaderProps) {
+export function Header({
+  variant,
+  alwaysVisible = false,
+  onOpenFriendManage,
+}: HeaderProps) {
   const [isHeaderVisible, setIsHeaderVisible] = useState(alwaysVisible);
   const [isDropDownOpen, SetIsDropDownOpen] = useState(false);
   const navigate = useNavigate();
@@ -55,6 +60,11 @@ export function Header({ variant, alwaysVisible = false }: HeaderProps) {
 
   const toggleDropdown = () => {
     SetIsDropDownOpen((prev) => !prev);
+  };
+
+  const handleFriendManageModalOpen = () => {
+    SetIsDropDownOpen(false);
+    onOpenFriendManage?.();
   };
 
   const handleLogout = async () => {
@@ -109,6 +119,13 @@ export function Header({ variant, alwaysVisible = false }: HeaderProps) {
 
                 {isDropDownOpen && (
                   <div className="absolute bg-[#2B2F36] right-0 mt-6 w-28  rounded-lg shadow-lg border-none p-1 z-50">
+                    <button
+                      type="button"
+                      className="text-white w-full px-4 py-2 text-center text-sm text-gray-700 hover:bg-gray-900 hover:rounded-md transition cursor-pointer"
+                      onClick={handleFriendManageModalOpen}
+                    >
+                      친구관리
+                    </button>
                     <button
                       type="button"
                       className="text-white w-full px-4 py-2 text-center text-sm text-gray-700 hover:bg-gray-900 hover:rounded-md transition cursor-pointer"

--- a/frontend/src/components/Modal/ModalBody.tsx
+++ b/frontend/src/components/Modal/ModalBody.tsx
@@ -6,5 +6,5 @@ type ModalBodyProps = {
 };
 
 export function ModalBody({ children, className = "" }: ModalBodyProps) {
-  return <div className={`p-8 ${className}`}>{children}</div>;
+  return <div className={`p-4 ${className}`}>{children}</div>;
 }

--- a/frontend/src/components/Modal/ModalCloseButton.tsx
+++ b/frontend/src/components/Modal/ModalCloseButton.tsx
@@ -1,3 +1,4 @@
+import { X } from "lucide-react";
 import { useModalContext } from "./index";
 
 type ModalCloseButtonProps = {
@@ -11,9 +12,9 @@ export function ModalCloseButton({ className = "" }: ModalCloseButtonProps) {
       type="button"
       onClick={onClose}
       aria-label="닫기"
-      className={`absolute right-5 top-5 grid h-9 w-9 place-items-center rounded-full text-white/80 hover:bg-white/10 hover:text-white focus:outline-none focus:ring-white/30 ${className}`}
+      className={`cursor-pointer absolute right-5 top-5 grid h-9 w-9 place-items-center rounded-full text-white/80 hover:bg-white/10 hover:text-white focus:outline-none  ${className}`}
     >
-      <span className="text-2xl leading-none">X</span>
+      <X />
     </button>
   );
 }

--- a/frontend/src/components/Modal/ModalContent.tsx
+++ b/frontend/src/components/Modal/ModalContent.tsx
@@ -8,7 +8,7 @@ type ModalContentProps = {
 export function ModalContent({ children, className = "" }: ModalContentProps) {
   return (
     <div
-      className={`relative w-[600px] max-w-[90vw] rounded-3xl bg-[#2B2F36] shadow-2xl ${className}`}
+      className={`relative w-[600px] max-w-[90vw] rounded-xl bg-[#2B2F36] ${className}`}
     >
       {children}
     </div>

--- a/frontend/src/components/Modal/ModalContent.tsx
+++ b/frontend/src/components/Modal/ModalContent.tsx
@@ -8,7 +8,7 @@ type ModalContentProps = {
 export function ModalContent({ children, className = "" }: ModalContentProps) {
   return (
     <div
-      className={`relative w-[600px] max-w-[90vw] rounded-xl bg-[#2B2F36] ${className}`}
+      className={`relative w-[560px] max-w-[80vw] rounded-xl bg-[#2B2F36] ${className}`}
     >
       {children}
     </div>

--- a/frontend/src/components/Modal/ModalOverlay.tsx
+++ b/frontend/src/components/Modal/ModalOverlay.tsx
@@ -11,7 +11,7 @@ export function ModalOverlay({ className = "" }: ModalOverlayProps) {
     <button
       type="button"
       aria-label="오버레이 닫기"
-      className={`absolute inset-0 bg-black/60 ${className}`}
+      className={`absolute inset-0 bg-black/80 ${className}`}
       onClick={onClose}
     />
   );

--- a/frontend/src/pages/Home/components/FriendTooltip.tsx
+++ b/frontend/src/pages/Home/components/FriendTooltip.tsx
@@ -1,0 +1,15 @@
+type FriendTooltipProps = {
+  nickname: string;
+};
+
+export default function FriendTooltip({ nickname }: FriendTooltipProps) {
+  return (
+    <div
+      role="tooltip"
+      className="absolute left-full top-1/2 z-50 ml-4 -translate-y-1/2 whitespace-nowrap rounded-xl border border-white/30 bg-[#1e2228] px-3 py-2 text-center"
+    >
+      <div className="absolute left-0 top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rotate-45 border-b border-l border-white/30 bg-[#1e2228]" />
+      <p className="text-sm font-semibold text-[#D6FDE5]">{nickname}</p>
+    </div>
+  );
+}

--- a/frontend/src/pages/Home/components/FriendTooltip.tsx
+++ b/frontend/src/pages/Home/components/FriendTooltip.tsx
@@ -1,15 +1,21 @@
 type FriendTooltipProps = {
   nickname: string;
+  introduction: string;
 };
 
-export default function FriendTooltip({ nickname }: FriendTooltipProps) {
+export default function FriendTooltip({
+  nickname,
+  introduction,
+}: FriendTooltipProps) {
   return (
     <div
       role="tooltip"
-      className="absolute left-full top-1/2 z-50 ml-4 -translate-y-1/2 whitespace-nowrap rounded-xl border border-white/30 bg-[#1e2228] px-3 py-2 text-center"
+      className="absolute left-full top-1/2 z-50 ml-4 -translate-y-1/2 whitespace-nowrap rounded-xl border border-white/30 bg-[#1e2228] px-3 py-2 text-left"
     >
       <div className="absolute left-0 top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rotate-45 border-b border-l border-white/30 bg-[#1e2228]" />
-      <p className="text-sm font-semibold text-[#D6FDE5]">{nickname}</p>
+      <p className="text-sm font-semibold text-[#D6FDE5]">
+        {nickname} <span className="text-[10px] font-thin">{introduction}</span>
+      </p>
     </div>
   );
 }

--- a/frontend/src/pages/Home/components/LeftSidebar.tsx
+++ b/frontend/src/pages/Home/components/LeftSidebar.tsx
@@ -5,6 +5,7 @@ import AddFriendModal from "@/pages/Home/components/Modals/AddFriendModal";
 import { QUERY_KEYS } from "@/apis/constants/queryKeys";
 import { friendApi } from "@/apis/services/friend";
 import type { FriendDetail } from "@/apis/types/friend";
+import FriendTooltip from "./FriendTooltip";
 
 type LeftSidebarProps = {
   onAddFriend?: () => void;
@@ -95,15 +96,7 @@ export default function LeftSidebar({
                 </button>
 
                 {hovered?.nickname === f.nickname && (
-                  <div
-                    role="tooltip"
-                    className="whitespace-nowrap absolute left-full top-1/2 z-50 ml-4 -translate-y-1/2 rounded-xl border border-white/30  bg-[#1e2228] px-3 py-2 text-center"
-                  >
-                    <div className="absolute left-0 top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rotate-45 border-l border-b border-white/30 bg-[#1e2228] " />
-                    <p className="text-sm font-semibold text-[#D6FDE5]">
-                      {f.nickname}
-                    </p>
-                  </div>
+                  <FriendTooltip nickname={f.nickname} />
                 )}
               </div>
             );

--- a/frontend/src/pages/Home/components/LeftSidebar.tsx
+++ b/frontend/src/pages/Home/components/LeftSidebar.tsx
@@ -1,31 +1,33 @@
 import { useState } from "react";
 import { Plus, User } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import AddFriendModal from "@/pages/Home/components/Modals/AddFriendModal";
-
-type Friend = {
-  id: string;
-  name: string;
-  avatarUrl?: string;
-};
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
+import { friendApi } from "@/apis/services/friend";
+import type { FriendDetail } from "@/apis/types/friend";
 
 type LeftSidebarProps = {
-  friends?: Friend[];
   onAddFriend?: () => void;
-  onSelectFriend?: (friendId: string) => void;
+  onSelectFriend?: (nickname: string) => void;
   selectedFriendId?: string;
 };
 
-const defaultFriends: Friend[] = [
-  { id: "1", name: "김철수" },
-];
-
 export default function LeftSidebar({
-  friends = defaultFriends,
   onAddFriend,
   onSelectFriend,
   selectedFriendId,
 }: LeftSidebarProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [hovered, setHovered] = useState<FriendDetail | null>(null);
+
+  const {
+    data: friends = [],
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: QUERY_KEYS.friend.all,
+    queryFn: friendApi.getList,
+  });
 
   const handleAddFriend = () => {
     setIsModalOpen(true);
@@ -33,55 +35,79 @@ export default function LeftSidebar({
   };
 
   return (
-    <aside className="flex w-20 flex-col items-center bg-[#2E323A] py-5">
+    <aside className="relative flex w-17 flex-col items-center bg-[#2E323A] py-5">
       <button
         type="button"
         onClick={handleAddFriend}
-        aria-label="친구 초대"
+        aria-label="친구 추가"
         className="mb-4 grid h-12 w-12 place-items-center rounded-2xl bg-[#3E7358] text-white shadow-[0_10px_30px_rgba(0,0,0,0.35)] hover:brightness-110 transition"
       >
         <Plus size={24} />
       </button>
 
-      <AddFriendModal open={isModalOpen} onClose={() => setIsModalOpen(false)} />
+      <AddFriendModal
+        open={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+      />
 
-      <nav className="flex w-full flex-1 flex-col items-center gap-4 overflow-y-auto px-2 pb-6">
-        {friends.map((f) => {
-          const selected = f.id === selectedFriendId;
+      {isError && (
+        <p className="mb-2 px-2 text-center text-[10px] text-red-300">
+          친구 목록을 불러오지 못했습니다
+        </p>
+      )}
 
-          return (
-            <button
-              key={f.id}
-              type="button"
-              onClick={() => onSelectFriend?.(f.id)}
-              className="flex w-full flex-col items-center"
-              aria-label={`${f.name} 프로필`}
-            >
+      <nav className="flex w-full flex-1 flex-col items-center gap-2 overflow-visible px-2">
+        {!isLoading &&
+          friends.map((f) => {
+            const selected = f.nickname === selectedFriendId;
+
+            return (
               <div
-                className={[
-                  "grid h-12 w-12 place-items-center rounded-2xl",
-                  "bg-[#3E7358] shadow-[0_10px_30px_rgba(0,0,0,0.30)]",
-                  "ring-2 ring-transparent",
-                  selected ? "ring-[#82C397]" : "",
-                ].join(" ")}
+                key={f.nickname}
+                className="relative flex w-full flex-col items-center"
+                onMouseEnter={() => setHovered(f)}
+                onMouseLeave={() => setHovered(null)}
               >
-                {f.avatarUrl ? (
-                  <img
-                    src={f.avatarUrl}
-                    alt={f.name}
-                    className="h-full w-full rounded-2xl object-cover"
-                  />
-                ) : (
-                  <User size={22} className="text-white" />
+                <button
+                  type="button"
+                  onClick={() => onSelectFriend?.(f.nickname)}
+                  className="flex w-full flex-col items-center"
+                  aria-label={`${f.nickname} 프로필`}
+                >
+                  <div
+                    className={[
+                      "grid h-12 w-12 place-items-center overflow-hidden rounded-2xl",
+                      "bg-[#3E7358] shadow-[0_10px_30px_rgba(0,0,0,0.30)]",
+                      "ring-2 ring-transparent",
+                      selected ? "ring-[#82C397]" : "",
+                    ].join(" ")}
+                  >
+                    {f.imageUrl ? (
+                      <img
+                        src={f.imageUrl}
+                        alt=""
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <User size={22} className="text-white" />
+                    )}
+                  </div>
+                </button>
+
+                {hovered?.nickname === f.nickname && (
+                  <div
+                    role="tooltip"
+                    className="whitespace-nowrap absolute left-full top-1/2 z-50 ml-4 -translate-y-1/2 rounded-xl border border-white/30  bg-[#1e2228] px-3 py-2 text-center"
+                  >
+                    <div className="absolute left-0 top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rotate-45 border-l border-b border-white/30 bg-[#1e2228] " />
+                    <p className="text-sm font-semibold text-[#D6FDE5]">
+                      {f.nickname}
+                    </p>
+                  </div>
                 )}
               </div>
-
-              <span className="mt-1 text-[10px] font-medium text-[#D6FDE5]/90">
-                {f.name}
-              </span>
-            </button>
-          );
-        })}
+            );
+          })}
       </nav>
     </aside>
   );

--- a/frontend/src/pages/Home/components/LeftSidebar.tsx
+++ b/frontend/src/pages/Home/components/LeftSidebar.tsx
@@ -96,7 +96,10 @@ export default function LeftSidebar({
                 </button>
 
                 {hovered?.nickname === f.nickname && (
-                  <FriendTooltip nickname={f.nickname} />
+                  <FriendTooltip
+                    nickname={f.nickname}
+                    introduction={f.introduction}
+                  />
                 )}
               </div>
             );

--- a/frontend/src/pages/Home/components/Modals/AddFriendModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/AddFriendModal.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from "react";
 import Modal from "@/components/Modal";
+import { friendApi } from "@/apis/services/friend";
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 type AddFriendModalProps = {
   open: boolean;
@@ -7,22 +10,41 @@ type AddFriendModalProps = {
 };
 
 export default function AddFriendModal({ open, onClose }: AddFriendModalProps) {
-  const [friendId, setFriendId] = useState("");
+  const [friendNickname, setFriendNickname] = useState("");
   const [submitted, setSubmitted] = useState(false);
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     if (!open) {
-      setFriendId("");
+      setFriendNickname("");
       setSubmitted(false);
     }
   }, [open]);
 
-  const handleSubmit = () => {
-    if (!friendId.trim()) return;
-    setSubmitted(true);
+  const { mutateAsync: addFriend, isPending: isAddingFriend } = useMutation({
+    mutationFn: (nickname: string) => friendApi.addFriend(nickname),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.friend.all });
+      console.log("친구 추가 성공"); //TODO: 토스트
+    },
+    onError: () => {
+      console.log("친구 추가 실패"); //TODO: 토스트
+    },
+  });
+
+  const handleSubmit = async () => {
+    const trimmedFriendNickname = friendNickname.trim();
+    try {
+      if (!trimmedFriendNickname) return;
+      await addFriend(trimmedFriendNickname);
+      setSubmitted(true);
+      onClose();
+    } catch (error) {
+      console.log("친구 추가 에러", error);
+    }
   };
 
-  const isDisabled = submitted || !friendId.trim();
+  const isDisabled = submitted || isAddingFriend || !friendNickname.trim();
 
   return (
     <Modal isOpen={open} onClose={onClose}>
@@ -32,18 +54,18 @@ export default function AddFriendModal({ open, onClose }: AddFriendModalProps) {
         <Modal.Header className="flex flex-col items-center text-center">
           <Modal.Title size="lg" />
           <p className="mt-4 text-sm font-medium text-[#D6FDE5]">
-            아이디를 입력해 주세요
+            닉네임을 입력해 주세요
           </p>
         </Modal.Header>
         <Modal.Body className="flex flex-col items-center pb-16">
           <div className="mt-12 w-full max-w-[360px]">
             <input
-              value={friendId}
-              onChange={(e) => setFriendId(e.target.value)}
+              value={friendNickname}
+              onChange={(e) => setFriendNickname(e.target.value)}
               disabled={submitted}
               placeholder=""
               className="h-14 w-full rounded-xl bg-white px-6 text-lg text-gray-900 outline-none disabled:opacity-90"
-              aria-label="친구 아이디"
+              aria-label="친구 닉네임"
             />
           </div>
 
@@ -63,7 +85,7 @@ export default function AddFriendModal({ open, onClose }: AddFriendModalProps) {
 
           {submitted && (
             <p className="mt-6 text-sm font-medium text-[#D6FDE5]">
-              김윤영 님과 친구가 되었습니다
+              {friendNickname} 님과 친구가 되었습니다
             </p>
           )}
         </Modal.Body>

--- a/frontend/src/pages/Home/components/Modals/AddFriendModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/AddFriendModal.tsx
@@ -58,7 +58,7 @@ export default function AddFriendModal({ open, onClose }: AddFriendModalProps) {
           </p>
         </Modal.Header>
         <Modal.Body className="flex flex-col items-center pb-16">
-          <div className="mt-12 w-full max-w-[360px]">
+          <div className="mt-6 w-full max-w-[360px]">
             <input
               value={friendNickname}
               onChange={(e) => setFriendNickname(e.target.value)}
@@ -74,7 +74,7 @@ export default function AddFriendModal({ open, onClose }: AddFriendModalProps) {
             onClick={handleSubmit}
             disabled={isDisabled}
             className={[
-              "mt-4 h-14 w-full max-w-[360px] rounded-xl text-lg font-semibold transition",
+              "mt-3 h-14 w-full max-w-[360px] rounded-xl text-lg font-semibold transition",
               isDisabled
                 ? "bg-[#C9CDCC] text-white cursor-not-allowed"
                 : "bg-[#3E7358] text-[#EDFFF4] hover:bg-emerald-800",

--- a/frontend/src/pages/Home/components/Modals/FriendManageModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/FriendManageModal.tsx
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import Modal from "@/components/Modal";
+import { friendApi } from "@/apis/services/friend";
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
+
+type FriendManageModalProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export default function FriendManageModal({
+  open,
+  onClose,
+}: FriendManageModalProps) {
+  const queryClient = useQueryClient();
+  const [removingNickname, setRemovingNickname] = useState<string | null>(null);
+
+  const {
+    data: friends = [],
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery({
+    queryKey: QUERY_KEYS.friend.all,
+    queryFn: friendApi.getList,
+    enabled: open,
+  });
+
+  const { mutateAsync: removeFriend } = useMutation({
+    mutationFn: (nickname: string) => friendApi.removeFriend(nickname),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.friend.all });
+    },
+    onError: (error) => {
+      console.error("친구 해제 실패", error); //TODO: 토스트
+    },
+  });
+
+  const handleRemove = async (nickname: string) => {
+    const ok = window.confirm(`${nickname} 님을 친구 목록에서 해제할까요?`); //TODO: confirm 모달
+    if (!ok) return;
+    setRemovingNickname(nickname);
+    try {
+      await removeFriend(nickname);
+    } catch {
+      // onError에서 로깅
+    } finally {
+      setRemovingNickname(null);
+    }
+  };
+
+  return (
+    <Modal isOpen={open} onClose={onClose}>
+      <Modal.Overlay />
+      <Modal.Content>
+        <Modal.CloseButton />
+        <Modal.Header className="flex flex-col items-center text-center">
+          <Modal.Title size="sm" />
+          <p className="mt-2 text-sm font-medium text-[#D6FDE5]">친구 관리</p>
+        </Modal.Header>
+
+        <Modal.Body className="max-h-[min(420px,60vh)] overflow-y-auto pb-15">
+          {isLoading && (
+            <p className="mt-6 text-center text-sm text-[#D6FDE5]/80">
+              불러오는 중…
+            </p>
+          )}
+          {isError && (
+            <div className="mt-6 text-center">
+              <p className="text-sm text-red-300">
+                목록을 불러오지 못했습니다.
+              </p>
+              <button
+                type="button"
+                onClick={() => refetch()}
+                className="mt-2 text-sm text-[#82C397] underline"
+              >
+                다시 시도
+              </button>
+            </div>
+          )}
+          {!isLoading && !isError && friends.length === 0 && (
+            <p className="mt-6 text-center text-sm text-[#D6FDE5]/80">
+              등록된 친구가 없습니다.
+            </p>
+          )}
+          {!isLoading && !isError && friends.length > 0 && (
+            <ul className="mt-4 w-full max-w-sm mx-auto">
+              {friends.map((friend) => {
+                const isRemoving = removingNickname === friend.nickname;
+                return (
+                  <li
+                    key={friend.nickname}
+                    className="flex items-center justify-between gap-4 py-3"
+                  >
+                    <span className="text-sm font-medium text-[#D6FDE5]">
+                      {friend.nickname}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => handleRemove(friend.nickname)}
+                      disabled={isRemoving}
+                      className="shrink-0 rounded-lg border border-red-500/30
+                                  px-3 py-1.5 text-xs font-medium text-red-400
+                                  transition
+                                  hover:bg-red-500/10
+                                  hover:border-red-500
+                                  hover:text-red-300
+                                  active:scale-95
+                                  disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {isRemoving ? "해제 중…" : "친구 해제"}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </Modal.Body>
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -1,9 +1,11 @@
+import { useState } from "react";
 import { useLocation } from "react-router-dom";
 import { Header } from "@/components/Header";
 import GroupSection from "@/pages/Home/components/GroupSection/GroupSection";
 import Achievement from "@/pages/Home/components/AchievementCard";
 import ProfileCard from "@/pages/Home/components/ProfileCard";
 import LeftSidebar from "@/pages/Home/components/LeftSidebar";
+import FriendManageModal from "@/pages/Home/components/Modals/FriendManageModal";
 
 type HomeLocationState = {
   openProfileSetupModal: boolean;
@@ -11,6 +13,7 @@ type HomeLocationState = {
 };
 
 const HomePage = () => {
+  const [isFriendManageOpen, setIsFriendManageOpen] = useState(false);
   const location = useLocation();
   const state = location.state as HomeLocationState;
 
@@ -19,7 +22,11 @@ const HomePage = () => {
 
   return (
     <div className="flex flex-col pt-[65px] w-full h-auto bg-gray-darkest">
-      <Header variant="dark" alwaysVisible />
+      <Header
+        variant="dark"
+        alwaysVisible
+        onOpenFriendManage={() => setIsFriendManageOpen(true)}
+      />
 
       <div className="flex">
         <LeftSidebar />
@@ -38,6 +45,10 @@ const HomePage = () => {
           </div>
         </div>
       </div>
+      <FriendManageModal
+        open={isFriendManageOpen}
+        onClose={() => setIsFriendManageOpen(false)}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## 변경점 
- 친구 목록 조회, 친구 추가, 친구 삭제 api를 연동하였습니다.
- 친구 프로필에 마우스 호버 했을 때 친구 `nickname`과 `introduction`이 툴팁에 뜨도록 구현했습니다.
- 친구 삭제 구현을 위해 친구 관리 모달을 추가하고 header의 드롭다운에서 진입할 수 있도록 구현하였습니다.

## 스크린샷
<img width="151" height="204" alt="스크린샷 2026-04-05 오후 4 26 16" src="https://github.com/user-attachments/assets/007d17a1-3b20-4c3d-b918-403a64a572a8" />
<img width="163" height="184" alt="스크린샷 2026-04-05 오후 4 27 48" src="https://github.com/user-attachments/assets/e01c6cc9-47f2-4f49-bc3d-c630569ae474" />
