### PR TITLE
기존 엔티티들에 BaseEntity 적용

### DIFF
--- a/backend/grit/src/main/java/grit/domain/auth/entity/RefreshToken.java
+++ b/backend/grit/src/main/java/grit/domain/auth/entity/RefreshToken.java
@@ -1,13 +1,13 @@
 package grit.domain.auth.entity;
 
 import grit.domain.member.entity.Member;
+import grit.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import java.time.Duration;
 import java.util.UUID;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import org.springframework.beans.factory.annotation.Value;
 
 @Entity
 @Table(name = "refresh_tokens")
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Value;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class RefreshToken {
+public class RefreshToken extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/grit/src/main/java/grit/domain/group/entity/Group.java
+++ b/backend/grit/src/main/java/grit/domain/group/entity/Group.java
@@ -1,5 +1,6 @@
 package grit.domain.group.entity;
 
+import grit.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import java.util.UUID;
 import lombok.*;
@@ -16,7 +17,8 @@ import java.util.List;
 @Table(name = "groups", indexes = {
         @Index(name = "idx_group_code", columnList = "code")
 })
-public class Group {
+public class Group extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -46,7 +48,11 @@ public class Group {
     }
 
     public void updateInfo(String name, UUID imageName) {
-        if (name != null) this.name = name;
-        if (imageName != null) this.imageName = imageName;
+        if (name != null) {
+            this.name = name;
+        }
+        if (imageName != null) {
+            this.imageName = imageName;
+        }
     }
 }

--- a/backend/grit/src/main/java/grit/domain/group/entity/MemberGroup.java
+++ b/backend/grit/src/main/java/grit/domain/group/entity/MemberGroup.java
@@ -1,10 +1,9 @@
 package grit.domain.group.entity;
 
 import grit.domain.member.entity.Member;
+import grit.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -13,7 +12,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "member_groups")
-public class MemberGroup {
+public class MemberGroup extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -25,8 +25,4 @@ public class MemberGroup {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id", nullable = false)
     private Group group;
-
-    @org.hibernate.annotations.CreationTimestamp
-    @Column(name = "group_join_date", nullable = false)
-    private LocalDateTime joinDate;
 }

--- a/backend/grit/src/main/java/grit/domain/member/entity/Member.java
+++ b/backend/grit/src/main/java/grit/domain/member/entity/Member.java
@@ -2,11 +2,11 @@ package grit.domain.member.entity;
 
 import grit.domain.member.constant.Role;
 import grit.domain.member.constant.SocialProvider;
+import grit.global.entity.BaseEntity;
 import grit.global.exception.InvalidInputException;
 import grit.global.exception.ProfileAlreadyInitializedException;
 import grit.global.exception.ProfileNotInitializedException;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.*;
 
@@ -22,7 +22,7 @@ import lombok.*;
 @AllArgsConstructor
 @Table(name = "members")
 @ToString(exclude = { "memberGroups", "friends" }) // lombok 무한루프 방지용
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -61,10 +61,6 @@ public class Member {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role = Role.PENDING;
-
-    @org.hibernate.annotations.CreationTimestamp
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime joinDate;
 
     // group
     @Builder.Default

--- a/backend/grit/src/main/java/grit/domain/member/entity/Member.java
+++ b/backend/grit/src/main/java/grit/domain/member/entity/Member.java
@@ -21,7 +21,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "members")
-@ToString(exclude = { "memberGroups", "friends" }) // lombok 무한루프 방지용
+@ToString(callSuper = true, exclude = { "memberGroups", "friends" }) // lombok 무한루프 방지용
 public class Member extends BaseEntity {
 
     @Id

--- a/backend/grit/src/main/java/grit/global/config/JpaConfig.java
+++ b/backend/grit/src/main/java/grit/global/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package grit.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = "auditorAwareImpl")
+public class JpaConfig {
+
+}

--- a/backend/grit/src/main/java/grit/global/entity/BaseEntity.java
+++ b/backend/grit/src/main/java/grit/global/entity/BaseEntity.java
@@ -1,0 +1,35 @@
+package grit.global.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @CreatedBy
+    @Column(nullable = false, updatable = false)
+    private Long createdBy;
+
+    @LastModifiedBy
+    @Column(nullable = false)
+    private Long updatedBy;
+}

--- a/backend/grit/src/main/java/grit/global/security/auditor/AuditorAwareImpl.java
+++ b/backend/grit/src/main/java/grit/global/security/auditor/AuditorAwareImpl.java
@@ -1,0 +1,32 @@
+package grit.global.security.auditor;
+
+import grit.domain.auth.infrastructure.jwt.MemberPrincipal;
+import java.util.Optional;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuditorAwareImpl implements AuditorAware<Long> {
+
+    private static final Long SYSTEM_ID = 0L;
+
+    @Override
+    public Optional<Long> getCurrentAuditor() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth == null || !auth.isAuthenticated()
+                || auth instanceof AnonymousAuthenticationToken) {
+            return Optional.of(SYSTEM_ID);
+        }
+
+        Object principal = auth.getPrincipal();
+        if (principal instanceof MemberPrincipal user) {
+            return Optional.of(user.id());
+        }
+
+        return Optional.of(SYSTEM_ID);
+    }
+}


### PR DESCRIPTION
# 변경점 👍
### Entity Auditing Infrastructure
- 생성/수정 시각(createdAt, updatedAt)과 사용자(createdBy, updatedBy)를 자동으로 관리하는 추상 클래스 BaseEntity를 grit.global.entity에 추가했습니다.
- Spring Security와 연동하여 현재 사용자를 식별하는 AuditorAwareImpl을 구현했습니다.
- JPA Auditing을 활성화하고 auditor를 등록하기 위해 JpaConfig를 추가했습니다.

### Domain Entity Refactoring
- Member, RefreshToken, Group, MemberGroup 엔티티가 BaseEntity를 상속하도록 변경되었습니다.
