### PR TITLE
RefreshToken Cookie 로컬 테스트 환경에서 저장 안되는 현상 수정

### DIFF
--- a/backend/grit/src/main/java/grit/global/util/CookieUtils.java
+++ b/backend/grit/src/main/java/grit/global/util/CookieUtils.java
@@ -14,7 +14,7 @@ public class CookieUtils {
         return ResponseCookie.from("refresh_token", refreshToken)
                 .httpOnly(true)
                 .secure(true)
-                .sameSite("Strict")
+                .sameSite("None")
                 .path("/")
                 .maxAge(refreshTokenExpirationMs / 1000)
                 .build();
@@ -24,7 +24,7 @@ public class CookieUtils {
         return ResponseCookie.from("refresh_token", "")
                 .httpOnly(true)
                 .secure(true)
-                .sameSite("Strict")
+                .sameSite("None")
                 .path("/")
                 .maxAge(0)
                 .build();


### PR DESCRIPTION
# 변경점 👍
RefreshToken Cookie에 Same-Site: Strict 옵션으로 인해 로컬 테스트 환경에서 쿠키 저장 안되는 현상 수정 (None으로 변경)
