### PR TITLE
feat: 투두 카테고리 sortOrder 및 순서 변경 API

### DIFF
--- a/backend/grit/src/main/java/grit/domain/todo/controller/TodoCategoryController.java
+++ b/backend/grit/src/main/java/grit/domain/todo/controller/TodoCategoryController.java
@@ -2,6 +2,7 @@ package grit.domain.todo.controller;
 
 import grit.domain.auth.infrastructure.jwt.MemberPrincipal;
 import grit.domain.todo.dto.CreateTodoCategoryRequestDto;
+import grit.domain.todo.dto.ReorderTodoCategoriesRequestDto;
 import grit.domain.todo.dto.TodoCategoryResponseDto;
 import grit.domain.todo.service.TodoCategoryService;
 import grit.global.security.MemberSelfAssert;
@@ -26,7 +27,7 @@ import java.util.List;
 public class TodoCategoryController {
     private final TodoCategoryService todoCategoryService;
 
-    @Operation(summary = "내 투두 카테고리 목록", description = "사용자가 등록한 투두 카테고리를 이름순으로 조회합니다.")
+    @Operation(summary = "내 투두 카테고리 목록", description = "사용자가 등록한 투두 카테고리를 표시 순서(sortOrder)대로 조회합니다.")
     @GetMapping("/api/users/{userId}/todo-categories")
     public ResponseEntity<List<TodoCategoryResponseDto>> list(
             @AuthenticationPrincipal MemberPrincipal principal,
@@ -49,6 +50,23 @@ public class TodoCategoryController {
         MemberSelfAssert.assertSameMember(principal, userId);
         TodoCategoryResponseDto created = todoCategoryService.create(userId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @Operation(summary = "투두 카테고리 순서 변경", description = "본인 카테고리 ID를 원하는 표시 순서대로 모두 나열합니다. 누락·추가 ID가 있으면 400입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "순서 저장 성공"),
+            @ApiResponse(responseCode = "400", description = "ID 목록 불일치·중복", content = @Content),
+            @ApiResponse(responseCode = "403", description = "본인이 아님", content = @Content),
+            @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
+    })
+    @PatchMapping("/api/users/{userId}/todo-categories/reorder")
+    public ResponseEntity<List<TodoCategoryResponseDto>> reorder(
+            @AuthenticationPrincipal MemberPrincipal principal,
+            @Parameter(description = "사용자 ID (PK)", example = "1") @PathVariable Long userId,
+            @Valid @RequestBody ReorderTodoCategoriesRequestDto request) {
+        MemberSelfAssert.assertSameMember(principal, userId);
+        List<TodoCategoryResponseDto> updated = todoCategoryService.reorder(userId, request);
+        return ResponseEntity.ok(updated);
     }
 
     @Operation(summary = "투두 카테고리 삭제", description = "해당 카테고리를 쓰는 투두는 카테고리만 해제됩니다.")

--- a/backend/grit/src/main/java/grit/domain/todo/dto/ReorderTodoCategoriesRequestDto.java
+++ b/backend/grit/src/main/java/grit/domain/todo/dto/ReorderTodoCategoriesRequestDto.java
@@ -1,0 +1,20 @@
+package grit.domain.todo.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ReorderTodoCategoriesRequestDto {
+    @NotEmpty
+    @Schema(
+            description = "본인 카테고리 ID를 원하는 표시 순서대로 나열 (전체 목록과 동일한 집합이어야 함)",
+            example = "[3, 1, 2]",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private List<@NotNull Long> categoryIds;
+}

--- a/backend/grit/src/main/java/grit/domain/todo/dto/TodoCategoryResponseDto.java
+++ b/backend/grit/src/main/java/grit/domain/todo/dto/TodoCategoryResponseDto.java
@@ -14,7 +14,10 @@ public class TodoCategoryResponseDto {
     @Schema(description = "카테고리 이름", example = "학교 과제")
     private String name;
 
+    @Schema(description = "표시 순서 (작을수록 앞)", example = "0")
+    private int sortOrder;
+
     public static TodoCategoryResponseDto from(TodoCategory category) {
-        return new TodoCategoryResponseDto(category.getId(), category.getName());
+        return new TodoCategoryResponseDto(category.getId(), category.getName(), category.getSortOrder());
     }
 }

--- a/backend/grit/src/main/java/grit/domain/todo/entity/TodoCategory.java
+++ b/backend/grit/src/main/java/grit/domain/todo/entity/TodoCategory.java
@@ -4,6 +4,7 @@ import grit.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Setter
@@ -24,4 +25,9 @@ public class TodoCategory {
 
     @Column(nullable = false, length = 50)
     private String name;
+
+    /** 소유자 기준 표시 순서 (0부터). 작을수록 앞에 표시. */
+    @Column(name = "sort_order", nullable = false)
+    @ColumnDefault("0")
+    private int sortOrder;
 }

--- a/backend/grit/src/main/java/grit/domain/todo/repository/TodoCategoryRepository.java
+++ b/backend/grit/src/main/java/grit/domain/todo/repository/TodoCategoryRepository.java
@@ -2,13 +2,18 @@ package grit.domain.todo.repository;
 
 import grit.domain.todo.entity.TodoCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface TodoCategoryRepository extends JpaRepository<TodoCategory, Long> {
 
-    List<TodoCategory> findByOwner_IdOrderByNameAsc(Long ownerId);
+    List<TodoCategory> findByOwner_IdOrderBySortOrderAscIdAsc(Long ownerId);
+
+    @Query("select coalesce(max(c.sortOrder), -1) from TodoCategory c where c.owner.id = :ownerId")
+    int findMaxSortOrderByOwnerId(@Param("ownerId") Long ownerId);
 
     Optional<TodoCategory> findByIdAndOwner_Id(Long id, Long ownerId);
 

--- a/backend/grit/src/main/java/grit/domain/todo/service/TodoCategoryService.java
+++ b/backend/grit/src/main/java/grit/domain/todo/service/TodoCategoryService.java
@@ -3,6 +3,7 @@ package grit.domain.todo.service;
 import grit.domain.member.entity.Member;
 import grit.domain.member.repository.MemberRepository;
 import grit.domain.todo.dto.CreateTodoCategoryRequestDto;
+import grit.domain.todo.dto.ReorderTodoCategoriesRequestDto;
 import grit.domain.todo.dto.TodoCategoryResponseDto;
 import grit.domain.todo.entity.TodoCategory;
 import grit.domain.todo.repository.TodoCategoryRepository;
@@ -13,7 +14,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -27,7 +34,7 @@ public class TodoCategoryService {
         if (!memberRepository.existsById(userId)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
         }
-        return todoCategoryRepository.findByOwner_IdOrderByNameAsc(userId).stream()
+        return todoCategoryRepository.findByOwner_IdOrderBySortOrderAscIdAsc(userId).stream()
                 .map(TodoCategoryResponseDto::from)
                 .toList();
     }
@@ -48,7 +55,38 @@ public class TodoCategoryService {
         TodoCategory category = new TodoCategory();
         category.setOwner(owner);
         category.setName(name);
+        int nextOrder = todoCategoryRepository.findMaxSortOrderByOwnerId(userId) + 1;
+        category.setSortOrder(nextOrder);
         return TodoCategoryResponseDto.from(todoCategoryRepository.save(category));
+    }
+
+    @Transactional
+    public List<TodoCategoryResponseDto> reorder(Long userId, ReorderTodoCategoriesRequestDto request) {
+        if (!memberRepository.existsById(userId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+        }
+
+        List<Long> orderedIds = request.getCategoryIds();
+        if (new HashSet<>(orderedIds).size() != orderedIds.size()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "카테고리 ID가 중복되었습니다.");
+        }
+
+        List<TodoCategory> owned = todoCategoryRepository.findByOwner_IdOrderBySortOrderAscIdAsc(userId);
+        Set<Long> expectedIds = owned.stream().map(TodoCategory::getId).collect(Collectors.toSet());
+        if (expectedIds.size() != orderedIds.size() || !expectedIds.equals(new HashSet<>(orderedIds))) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "등록된 카테고리와 동일한 ID 목록을 보내주세요.");
+        }
+
+        Map<Long, TodoCategory> byId = owned.stream()
+                .collect(Collectors.toMap(TodoCategory::getId, Function.identity()));
+        for (int i = 0; i < orderedIds.size(); i++) {
+            TodoCategory cat = Objects.requireNonNull(byId.get(orderedIds.get(i)));
+            cat.setSortOrder(i);
+        }
+
+        return todoCategoryRepository.findByOwner_IdOrderBySortOrderAscIdAsc(userId).stream()
+                .map(TodoCategoryResponseDto::from)
+                .toList();
     }
 
     @Transactional

--- a/backend/grit/src/main/java/grit/domain/todo/service/TodoCategoryService.java
+++ b/backend/grit/src/main/java/grit/domain/todo/service/TodoCategoryService.java
@@ -84,8 +84,8 @@ public class TodoCategoryService {
             cat.setSortOrder(i);
         }
 
-        return todoCategoryRepository.findByOwner_IdOrderBySortOrderAscIdAsc(userId).stream()
-                .map(TodoCategoryResponseDto::from)
+        return orderedIds.stream()
+                .map(id -> TodoCategoryResponseDto.from(byId.get(id)))
                 .toList();
     }
 

--- a/backend/grit/src/main/java/grit/domain/todo/service/TodoService.java
+++ b/backend/grit/src/main/java/grit/domain/todo/service/TodoService.java
@@ -42,10 +42,6 @@ public class TodoService {
         return todoRepository.findByOwnerIdWithRelations(userId);
     }
 
-    /**
-     * 해당 그룹 멤버가 작성한 투두 전체. {@code focusUserId}는 그룹 멤버여야 하며, 해당 작성자의 투두가 목록 최상단에 오도록 정렬합니다.
-     * 요청자는 그룹 멤버여야 합니다.
-     */
     public List<Todo> findForGroup(String groupCode, Long requesterUserId, Long focusUserId) {
         Member requester = memberRepository.findById(requesterUserId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));

--- a/backend/grit/src/main/resources/static/style.css
+++ b/backend/grit/src/main/resources/static/style.css
@@ -1556,6 +1556,24 @@ textarea.form-input {
     flex-wrap: wrap;
 }
 
+/* Todo category chips — drag reorder */
+.todo-category-chips .todo-category-chip {
+    cursor: grab;
+    user-select: none;
+}
+
+.todo-category-chips .todo-category-chip:active {
+    cursor: grabbing;
+}
+
+.todo-category-chips .todo-category-chip.dragging {
+    opacity: 0.55;
+}
+
+.todo-category-chips .todo-category-chip.drag-over {
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.65);
+}
+
 /* ═══════════════════════════════════════════
    Group Grid & Cards
    ═══════════════════════════════════════════ */

--- a/backend/grit/src/main/resources/static/todo.html
+++ b/backend/grit/src/main/resources/static/todo.html
@@ -79,7 +79,7 @@
                 <div class="todo-main-col">
                     <div class="glass-card todo-category-manager" style="margin-bottom:1rem;padding:1rem 1.25rem;">
                         <h3 style="margin:0 0 0.75rem;font-size:1rem;">내 카테고리</h3>
-                        <p style="margin:0 0 0.75rem;font-size:13px;color:var(--text-muted);">이름 변경은 불가합니다. 삭제 시 해당 카테고리만 투두에서 해제됩니다.</p>
+                        <p style="margin:0 0 0.75rem;font-size:13px;color:var(--text-muted);">이름 변경은 불가합니다. 칩을 드래그하면 순서를 바꿀 수 있습니다. 삭제 시 해당 카테고리만 투두에서 해제됩니다.</p>
                         <div style="display:flex;gap:0.5rem;flex-wrap:wrap;align-items:center;margin-bottom:0.75rem;">
                             <input type="text" id="new-category-name" class="form-input form-input-sm" placeholder="새 카테고리 이름" maxlength="50" style="flex:1;min-width:140px;" />
                             <button type="button" class="btn btn-outline btn-sm" id="add-category-btn">등록</button>

--- a/backend/grit/src/main/resources/static/todo.js
+++ b/backend/grit/src/main/resources/static/todo.js
@@ -94,6 +94,22 @@ async function deleteTodoCategory(categoryId) {
     }
 }
 
+/** @param {number[]} categoryIds 본인 카테고리 ID 전체를 원하는 순서대로 */
+async function reorderTodoCategories(categoryIds) {
+    const userId = getMemberId();
+    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/users/${userId}/todo-categories/reorder`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ categoryIds })
+    });
+    if (response.status === 403) throw new Error('본인 카테고리만 순서를 바꿀 수 있습니다.');
+    if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error(err.message || '순서 변경에 실패했습니다.');
+    }
+    return response.json();
+}
+
 /**
  * 그룹 투두 목록. 멤버만 호출 가능.
  * @param {string} groupCode
@@ -185,6 +201,8 @@ async function deleteTodo(todoId) {
 
 let allTodos = [];
 let todoCategories = [];
+/** @type {number|null} */
+let categoryDragId = null;
 let activeFilter = 'all';
 let activeCategoryFilter = '';
 
@@ -468,7 +486,7 @@ function renderCategoryManageList() {
         return;
     }
     ul.innerHTML = todoCategories.map(c => `
-        <li style="display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:999px;background:rgba(99,102,241,0.12);font-size:13px;">
+        <li draggable="true" data-cat-id="${c.id}" class="todo-category-chip" style="display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:999px;background:rgba(99,102,241,0.12);font-size:13px;">
             <span>${escapeHtml(c.name)}</span>
             <button type="button" class="icon-btn danger" data-del-cat="${c.id}" title="삭제" style="padding:2px;width:24px;height:24px;">×</button>
         </li>`).join('');
@@ -488,7 +506,9 @@ async function loadCategories() {
 document.addEventListener('DOMContentLoaded', () => {
     if (!checkAuth()) return;
 
-    document.getElementById('category-manage-list').addEventListener('click', async e => {
+    const categoryManageList = document.getElementById('category-manage-list');
+
+    categoryManageList.addEventListener('click', async e => {
         const del = e.target.closest('[data-del-cat]');
         if (!del) return;
         const id = Number(del.getAttribute('data-del-cat'));
@@ -498,6 +518,64 @@ document.addEventListener('DOMContentLoaded', () => {
             await loadCategories();
             await loadTodos();
             toast.info('카테고리를 삭제했습니다.');
+        } catch (err) {
+            toast.error(err.message);
+        }
+    });
+
+    categoryManageList.addEventListener('dragstart', e => {
+        if (e.target.closest('button')) {
+            e.preventDefault();
+            return;
+        }
+        const li = e.target.closest('[data-cat-id]');
+        if (!li) return;
+        categoryDragId = Number(li.getAttribute('data-cat-id'));
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', String(categoryDragId));
+        li.classList.add('dragging');
+    });
+
+    categoryManageList.addEventListener('dragend', e => {
+        const li = e.target.closest('[data-cat-id]');
+        if (li) li.classList.remove('dragging');
+        categoryManageList.querySelectorAll('.drag-over').forEach(el => el.classList.remove('drag-over'));
+        categoryDragId = null;
+    });
+
+    categoryManageList.addEventListener('dragover', e => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        const li = e.target.closest('[data-cat-id]');
+        if (!li || categoryDragId == null) return;
+        categoryManageList.querySelectorAll('.drag-over').forEach(el => el.classList.remove('drag-over'));
+        li.classList.add('drag-over');
+    });
+
+    categoryManageList.addEventListener('dragleave', e => {
+        const li = e.target.closest('[data-cat-id]');
+        if (li && !li.contains(e.relatedTarget)) li.classList.remove('drag-over');
+    });
+
+    categoryManageList.addEventListener('drop', async e => {
+        e.preventDefault();
+        const dropLi = e.target.closest('[data-cat-id]');
+        if (!dropLi || categoryDragId == null) return;
+        const dropId = Number(dropLi.getAttribute('data-cat-id'));
+        const dragId = categoryDragId;
+        dropLi.classList.remove('drag-over');
+        if (dragId === dropId) return;
+        const ids = todoCategories.map(c => c.id);
+        const from = ids.indexOf(dragId);
+        const to = ids.indexOf(dropId);
+        if (from < 0 || to < 0) return;
+        const next = [...ids];
+        next.splice(from, 1);
+        next.splice(to, 0, dragId);
+        try {
+            await reorderTodoCategories(next);
+            await loadCategories();
+            toast.success('카테고리 순서를 변경했습니다.');
         } catch (err) {
             toast.error(err.message);
         }


### PR DESCRIPTION
- 카테고리 정렬용 sort_order 컬럼 추가
- PATCH /todo-categories/reorder API 구현 (드래그 앤 드롭 대응)
- 목록 조회 시 sort_order 기준 오름차순 정렬 적용