### PR TITLE
refactor: apiClient 분리

### DIFF
--- a/frontend/src/apis/client/apiClient.ts
+++ b/frontend/src/apis/client/apiClient.ts
@@ -3,15 +3,24 @@ import { API_BASE_URL } from "@/apis/constants/endpoints";
 import { PATHS } from "@/routes/path";
 import { ENDPOINTS } from "@/apis/constants/endpoints";
 
-export const apiClient = axios.create({
+const refreshClient = axios.create({
   baseURL: API_BASE_URL,
   timeout: 10000,
+  withCredentials: true,
   headers: {
     "Content-Type": "application/json",
   },
 });
 
-//요청 인터셉터
+export const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+  timeout: 10000,
+  withCredentials: true,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
 apiClient.interceptors.request.use(
   (config) => {
     const authStorage = localStorage.getItem("auth-storage");
@@ -30,18 +39,14 @@ apiClient.interceptors.request.use(
   (error) => Promise.reject(error),
 );
 
-//응답 인터셉터
 let isRefreshingToken = false;
-
-//refresh가 끝날 때까지 기다려야 하는 요청들을 담아두기 위한 배열
 let pendingRequest: ((token: string) => void)[] = [];
 
-//새로운 토큰이 발급되면 대기 중인 요청들에게 새 토큰 전달
 const runPendingRequests = (newAccessToken: string) => {
   pendingRequest.forEach((callback) => callback(newAccessToken));
+  pendingRequest = [];
 };
 
-//대기중인 요청 추가
 const addPendingRequest = (callback: (token: string) => void) => {
   pendingRequest.push(callback);
 };
@@ -69,10 +74,8 @@ apiClient.interceptors.response.use(
       isRefreshingToken = true;
 
       try {
-        const refreshResponse = await axios.post(
-          `${API_BASE_URL}${ENDPOINTS.AUTH.REFRESH}`,
-          {},
-          { withCredentials: true },
+        const refreshResponse = await refreshClient.post(
+          ENDPOINTS.AUTH.REFRESH,
         );
 
         const newAccessToken = refreshResponse.data.accessToken;
@@ -86,7 +89,9 @@ apiClient.interceptors.response.use(
 
         runPendingRequests(newAccessToken);
 
+        originalRequest.headers = originalRequest.headers ?? {};
         originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+
         return apiClient(originalRequest);
       } catch (refreshError) {
         console.error("토큰 재발급 실패:", refreshError);


### PR DESCRIPTION
## 변경점 
- 이전 요청들이 계속 남아있는 문제 방지하기 위해 pendingRequest 처리 후 배열을 비우도록 처리하였습니다.
- refresh 요청이 interceptor를 타면서 발생할 수 있는 무한 루프 및 중복 재요청을 방지하기 위해 `apiClient` 와 `refreshClient`로 나누었고 `refreshClient`에는 interceptor를 적용하지 않았습니다.

