### PR TITLE
feat: Toast Context 도입 및 성공 / 실패 토스트 전역 적용

### DIFF
--- a/frontend/src/apis/services/storage.ts
+++ b/frontend/src/apis/services/storage.ts
@@ -1,0 +1,27 @@
+const STORAGE_KEYS = {
+  ACCESS_TOKEN: "grit.accessToken",
+  AUTH: "grit.auth",
+} as const;
+
+function getStorage() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return window.localStorage;
+}
+
+export function getAccessToken() {
+  return getStorage()?.getItem(STORAGE_KEYS.ACCESS_TOKEN) ?? null;
+}
+
+export function setAccessToken(accessToken: string) {
+  getStorage()?.setItem(STORAGE_KEYS.ACCESS_TOKEN, accessToken);
+}
+
+export function removeAccessToken() {
+  getStorage()?.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
+}
+
+export function getAuthStorage(){
+  
+}

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -1,0 +1,64 @@
+import {
+  useState,
+  useCallback,
+  useContext,
+  createContext,
+  type ReactNode,
+  useMemo,
+} from "react";
+import Toast, { type ToastPayload } from "@/components/Toast";
+
+type ToastVariant = "success" | "error";
+
+type ToastContextValue = {
+  notify: (text: string, variant?: ToastVariant) => void;
+  clearToast: () => void;
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+type ToastProviderProps = {
+  children: ReactNode;
+};
+
+export function ToastProvider({ children }: ToastProviderProps) {
+  const [toast, setToast] = useState<ToastPayload | null>(null);
+
+  const clearToast = useCallback(() => setToast(null), []);
+
+  const notify = useCallback(
+    (text: string, variant: ToastVariant = "success") => {
+      setToast((prev) => ({
+        key: (prev?.key ?? 0) + 1,
+        text,
+        variant,
+      }));
+    },
+    [],
+  );
+
+  const value = useMemo(
+    () => ({
+      notify,
+      clearToast,
+    }),
+    [notify, clearToast],
+  );
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <Toast toast={toast} onClear={clearToast} />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToastContext() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error(
+      "useToastContext는 ToastProvider 내부에서만 사용할 수 있습니다.",
+    );
+  }
+  return context;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { ToastProvider } from "@/contexts/ToastContext";
 import "@/index.css";
 import { router } from "@/routes";
 
@@ -11,7 +12,9 @@ const queryClient = new QueryClient();
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <ToastProvider>
+        <RouterProvider router={router} />
+      </ToastProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   </StrictMode>,

--- a/frontend/src/pages/Home/components/FriendTooltip.tsx
+++ b/frontend/src/pages/Home/components/FriendTooltip.tsx
@@ -1,21 +1,33 @@
+import { createPortal } from "react-dom";
+
 type FriendTooltipProps = {
   nickname: string;
   introduction: string;
+  top: number;
+  left: number;
 };
 
 export default function FriendTooltip({
   nickname,
   introduction,
+  top,
+  left,
 }: FriendTooltipProps) {
-  return (
+  return createPortal(
     <div
       role="tooltip"
-      className="absolute left-full top-1/2 z-50 ml-4 -translate-y-1/2 whitespace-nowrap rounded-xl border border-white/30 bg-[#1e2228] px-3 py-2 text-left"
+      className="fixed z-50 whitespace-nowrap rounded-xl border border-white/30 bg-[#1e2228] px-3 py-2 text-left"
+      style={{
+        top,
+        left,
+        transform: "translateY(-50%)",
+      }}
     >
       <div className="absolute left-0 top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rotate-45 border-b border-l border-white/30 bg-[#1e2228]" />
       <p className="text-sm font-semibold text-[#D6FDE5]">
         {nickname} <span className="text-[10px] font-thin">{introduction}</span>
       </p>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/frontend/src/pages/Home/components/LeftSidebar.tsx
+++ b/frontend/src/pages/Home/components/LeftSidebar.tsx
@@ -41,6 +41,28 @@ export default function LeftSidebar({
     onAddFriend?.();
   };
 
+  const [tooltipPosition, setTooltipPosition] = useState<{
+    top: number;
+    left: number;
+  } | null>(null);
+
+  const handleMouseEnter = (
+    e: React.MouseEvent<HTMLButtonElement>,
+    friend: FriendDetail,
+  ) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    setHovered(friend);
+    setTooltipPosition({
+      top: rect.top + rect.height / 2,
+      left: rect.right + 12,
+    });
+  };
+
+  const handleMouseLeave = () => {
+    setHovered(null);
+    setTooltipPosition(null);
+  };
+
   return (
     <aside className="flex w-17 flex-col items-center bg-[#2E323A] py-5">
       <button
@@ -72,12 +94,12 @@ export default function LeftSidebar({
               <div
                 key={f.nickname}
                 className="relative flex w-full flex-col items-center"
-                onMouseEnter={() => setHovered(f)}
-                onMouseLeave={() => setHovered(null)}
               >
                 <button
                   type="button"
                   onClick={() => onSelectFriend?.(f.nickname)}
+                  onMouseEnter={(e) => handleMouseEnter(e, f)}
+                  onMouseLeave={handleMouseLeave}
                   className="flex w-full flex-col items-center"
                   aria-label={`${f.nickname} 프로필`}
                 >
@@ -101,10 +123,12 @@ export default function LeftSidebar({
                   </div>
                 </button>
 
-                {hovered?.nickname === f.nickname && (
+                {hovered?.nickname === f.nickname && tooltipPosition && (
                   <FriendTooltip
                     nickname={f.nickname}
                     introduction={f.introduction}
+                    top={tooltipPosition.top}
+                    left={tooltipPosition.left}
                   />
                 )}
               </div>

--- a/frontend/src/pages/Home/components/Modals/AddFriendModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/AddFriendModal.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
-import Modal from "@/components/Modal";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useToastContext } from "@/contexts/ToastContext";
 import { friendApi } from "@/apis/domains/friend/api";
 import { QUERY_KEYS } from "@/apis/constants/queryKeys";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import Modal from "@/components/Modal";
 
 type AddFriendModalProps = {
   open: boolean;
@@ -12,6 +13,8 @@ type AddFriendModalProps = {
 export default function AddFriendModal({ open, onClose }: AddFriendModalProps) {
   const [friendNickname, setFriendNickname] = useState("");
   const [submitted, setSubmitted] = useState(false);
+
+  const { notify } = useToastContext();
   const queryClient = useQueryClient();
 
   useEffect(() => {
@@ -25,10 +28,10 @@ export default function AddFriendModal({ open, onClose }: AddFriendModalProps) {
     mutationFn: (nickname: string) => friendApi.addFriend(nickname),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.friend.all });
-      console.log("친구 추가 성공"); //TODO: 토스트
+      notify("친구 추가가 완료되었습니다.", "success");
     },
     onError: () => {
-      console.log("친구 추가 실패"); //TODO: 토스트
+      notify("친구 추가에 실패했습니다. 다시 시도해주세요.", "error");
     },
   });
 

--- a/frontend/src/pages/Home/components/Modals/AddFriendModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/AddFriendModal.tsx
@@ -30,7 +30,8 @@ export default function AddFriendModal({ open, onClose }: AddFriendModalProps) {
       await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.friend.all });
       notify("친구 추가가 완료되었습니다.", "success");
     },
-    onError: () => {
+    onError: (error) => {
+      console.log("친구 추가 실패", error);
       notify("친구 추가에 실패했습니다. 다시 시도해주세요.", "error");
     },
   });

--- a/frontend/src/pages/Home/components/Modals/CreateGroupModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/CreateGroupModal.tsx
@@ -6,6 +6,7 @@ import { groupApi } from "@/apis/domains/group/api";
 import { fileApi } from "@/apis/domains/file/api";
 import { ImageUploader } from "@/components/ImageUploader";
 import { QUERY_KEYS } from "@/apis/constants/queryKeys";
+import { useToastContext } from "@/contexts/ToastContext";
 
 type CreateGroupModalProps = {
   open: boolean;
@@ -21,6 +22,7 @@ export default function CreateGroupModal({
   const [inviteCode, setInviteCode] = useState("");
   const [_, setCopied] = useState(false);
 
+  const { notify } = useToastContext();
   const queryClient = useQueryClient();
 
   const { mutateAsync: createNewGroup, isPending } = useMutation({
@@ -46,9 +48,11 @@ export default function CreateGroupModal({
     onSuccess: async (newGroup) => {
       setInviteCode(newGroup.groupCode);
       await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.groups.my });
+      notify("새로운 그룹이 생성되었습니다.", "success");
     },
     onError: (error) => {
       console.error("그룹 생성 실패", error);
+      notify("그룹 생성에 실패했습니다. 다시 시도해주세요.", "error");
     },
   });
 

--- a/frontend/src/pages/Home/components/Modals/FriendManageModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/FriendManageModal.tsx
@@ -35,6 +35,7 @@ export default function FriendManageModal({
     mutationFn: (nickname: string) => friendApi.removeFriend(nickname),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.friend.all });
+      notify("친구가 해제되었습니다.", "success");
     },
     onError: (error) => {
       console.log("친구 해제 실패", error);

--- a/frontend/src/pages/Home/components/Modals/FriendManageModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/FriendManageModal.tsx
@@ -1,6 +1,7 @@
+import { User } from "lucide-react";
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { User } from "lucide-react";
+import { useToastContext } from "@/contexts/ToastContext";
 import Modal from "@/components/Modal";
 import { friendApi } from "@/apis/domains/friend/api";
 import { QUERY_KEYS } from "@/apis/constants/queryKeys";
@@ -14,7 +15,9 @@ export default function FriendManageModal({
   open,
   onClose,
 }: FriendManageModalProps) {
+  const { notify } = useToastContext();
   const queryClient = useQueryClient();
+
   const [removingNickname, setRemovingNickname] = useState<string | null>(null);
 
   const {
@@ -34,7 +37,8 @@ export default function FriendManageModal({
       await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.friend.all });
     },
     onError: (error) => {
-      console.error("친구 해제 실패", error); //TODO: 토스트
+      console.log("친구 해제 실패", error);
+      notify("친구 해제에 실패했습니다.", "error");
     },
   });
 

--- a/frontend/src/pages/Home/components/Modals/GroupSettingsModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/GroupSettingsModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
+import { useToastContext } from "@/contexts/ToastContext";
 import Modal from "@/components/Modal";
 import { groupApi } from "@/apis/domains/group/api";
 import { fileApi } from "@/apis/domains/file/api";
@@ -25,6 +26,8 @@ export default function GroupSettingsModal({
   const [baseGroupImage, setBaseGroupImage] = useState(initialImage);
   const [groupName, setGroupName] = useState(initialName);
   const [imageFile, setImageFile] = useState<File | null>(null);
+
+  const { notify } = useToastContext();
 
   const { data: groupInfo } = useQuery({
     queryKey: QUERY_KEYS.groups.detail(groupCode),
@@ -76,16 +79,18 @@ export default function GroupSettingsModal({
           queryKey: QUERY_KEYS.groups.my,
         });
         handleClose();
+        notify("그룹 정보가 수정되었습니다", "success");
       },
 
       onError: (error) => {
         console.error("그룹 정보 수정 실패:", error);
+        notify("그룹 정보 수정에 실패했습니다. 다시 시도해주세요", "error");
       },
     });
 
   const handleSave = async () => {
     if (!groupName.trim()) {
-      alert("그룹 이름을 입력해주세요."); //TODO: 확인 모달로 변경
+      notify("그룹 이름을 입력해주세요", "error");
       return;
     }
     await updateGroup();

--- a/frontend/src/pages/Home/components/Modals/JoinGroupModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/JoinGroupModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useToastContext } from "@/contexts/ToastContext";
 import Modal from "@/components/Modal";
 import { groupApi } from "@/apis/domains/group/api";
 import { QUERY_KEYS } from "@/apis/constants/queryKeys";
@@ -11,6 +12,8 @@ type JoinGroupModalProps = {
 
 export default function JoinGroupModal({ open, onClose }: JoinGroupModalProps) {
   const [inviteCode, setInviteCode] = useState("");
+
+  const { notify } = useToastContext();
   const queryClient = useQueryClient();
 
   const { mutateAsync: joinGroup, isPending } = useMutation({
@@ -19,9 +22,11 @@ export default function JoinGroupModal({ open, onClose }: JoinGroupModalProps) {
       await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.groups.my });
       setInviteCode("");
       onClose();
+      notify("그룹 참여가 완료되었습니다", "success");
     },
     onError: (error) => {
       console.log("그룹 참여 실패", error);
+      notify("그룹 참여에 실패했습니다. 다시 시도해주세요.", "success");
     },
   });
 

--- a/frontend/src/pages/Home/components/Modals/JoinGroupModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/JoinGroupModal.tsx
@@ -26,7 +26,7 @@ export default function JoinGroupModal({ open, onClose }: JoinGroupModalProps) {
     },
     onError: (error) => {
       console.log("그룹 참여 실패", error);
-      notify("그룹 참여에 실패했습니다. 다시 시도해주세요.", "success");
+      notify("그룹 참여에 실패했습니다. 다시 시도해주세요.", "error");
     },
   });
 

--- a/frontend/src/pages/Home/components/Modals/ProfileSettingsModal.tsx
+++ b/frontend/src/pages/Home/components/Modals/ProfileSettingsModal.tsx
@@ -1,6 +1,7 @@
+import { Loader2 } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Loader2 } from "lucide-react";
+import { useToastContext } from "@/contexts/ToastContext";
 import { userApi } from "@/apis/domains/user/api";
 import { fileApi } from "@/apis/domains/file/api";
 import Modal from "@/components/Modal";
@@ -26,6 +27,8 @@ export default function ProfileSettingsModal({
   const [dDayDate, setDDayDate] = useState("");
   const [dDayTitle, setDDayTitle] = useState("");
   const [weeklyStudyTimeGoal, setWeeklyStudyTimeGoal] = useState("");
+
+  const { notify } = useToastContext();
 
   const {
     data: member,
@@ -116,19 +119,20 @@ export default function ProfileSettingsModal({
         userApi.checkNicknameAvailability(trimmedNickname),
       onSuccess: (data) => {
         if (data.isAvailable) {
-          console.log("사용 가능 닉네임"); //TODO: 토스트
+          notify("사용 가능한 닉네임입니다.", "success");
         } else {
-          console.log("이미 사용중인 닉네임"); //TODO: 토스트
+          notify("이미 사용중인 닉네임입니다.", "error");
         }
       },
-      onError: () => {
-        console.log("요청 실패"); //TODO: 토스트
+      onError: (error) => {
+        console.log("닉네임 사용 불가", error);
+        notify("오류가 발생했습니다. 다시 시도해주세요.", "error");
       },
     });
 
   const handleCheckNicknameDuplicate = () => {
     const trimmedNickname = nickname.trim();
-    if (!trimmedNickname) return; //TODO: 토스트
+    if (!trimmedNickname) return;
     checkNicknameDuplicate(trimmedNickname);
   };
 

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -1,7 +1,5 @@
 import { useState } from "react";
 import { useLocation } from "react-router-dom";
-import Toast from "@/components/Toast";
-import { useToast } from "@/hooks/useToast";
 import { Header } from "@/components/Header";
 import GroupSection from "@/pages/Home/components/GroupSection/GroupSection";
 import Achievement from "@/pages/Home/components/AchievementCard";
@@ -15,7 +13,6 @@ type HomeLocationState = {
 };
 
 const HomePage = () => {
-  const { toast, clearToast } = useToast();
   const [isFriendManageOpen, setIsFriendManageOpen] = useState(false);
   const location = useLocation();
   const state = location.state as HomeLocationState;
@@ -29,7 +26,11 @@ const HomePage = () => {
 
       <div className="flex h-screen overflow-hidden overscroll-contain">
         <aside className="w-17 shrink-0 bg-[#2E323A] py-5">
-          <LeftSidebar onOpenFriendManage={() => setIsFriendManageOpen(true)} />
+          <div className="overflow-y-auto h-full">
+            <LeftSidebar
+              onOpenFriendManage={() => setIsFriendManageOpen(true)}
+            />
+          </div>
         </aside>
 
         <div className="flex-1 overflow-y-auto overscroll-contain">
@@ -50,7 +51,6 @@ const HomePage = () => {
         open={isFriendManageOpen}
         onClose={() => setIsFriendManageOpen(false)}
       />
-      <Toast toast={toast} onClear={clearToast} />
     </div>
   );
 };

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { useLocation } from "react-router-dom";
+import Toast from "@/components/Toast";
+import { useToast } from "@/hooks/useToast";
 import { Header } from "@/components/Header";
 import GroupSection from "@/pages/Home/components/GroupSection/GroupSection";
 import Achievement from "@/pages/Home/components/AchievementCard";
@@ -13,6 +15,7 @@ type HomeLocationState = {
 };
 
 const HomePage = () => {
+  const { toast, clearToast } = useToast();
   const [isFriendManageOpen, setIsFriendManageOpen] = useState(false);
   const location = useLocation();
   const state = location.state as HomeLocationState;
@@ -25,7 +28,7 @@ const HomePage = () => {
       <Header variant="dark" alwaysVisible />
 
       <div className="flex h-screen overflow-hidden overscroll-contain">
-        <aside className="w-17 shrink-0 overflow-y-auto bg-[#2E323A] py-5">
+        <aside className="w-17 shrink-0 bg-[#2E323A] py-5">
           <LeftSidebar onOpenFriendManage={() => setIsFriendManageOpen(true)} />
         </aside>
 
@@ -47,6 +50,7 @@ const HomePage = () => {
         open={isFriendManageOpen}
         onClose={() => setIsFriendManageOpen(false)}
       />
+      <Toast toast={toast} onClear={clearToast} />
     </div>
   );
 };


### PR DESCRIPTION
## 변경점

- `Toast Context`를 도입해 전역에서 토스트를 공통으로 사용할 수 있도록 구조를 정리했습니다.
- 그룹 생성, 친구 추가/삭제 등 주요 액션의 성공 / 실패 케이스에 토스트 알림을 일괄 적용했습니다.

## 개선점
- 기존 props drilling 기반 토스트 전달 흐름을 Context 기반으로 전환했습니다.
- 사이드바 영역에서 overflow로 인해 툴팁이 잘리는 문제를 해결했습니다.
    - 툴팁을 `createPortal`을 사용하여 `document.body`로 분리 렌더링되도록 변경했습니다.
    - hover 대상 요소의 위치를 `getBoundingClientRect()`로 계산하여 툴팁 위치를 동적으로 설정하도록 개선했습니다.

## Test

- [x] 친구 추가 성공/실패 시 각각 토스트 노출 확인
- [x] 친구 삭제 성공/실패 시 각각 토스트 노출 확인
- [x] 그룹 생성 성공/실패 시 각각 토스트 노출 확인
- [x] 모달이 닫혀도 토스트 정상 표시 확인
