### PR TITLE
feat: 최근 7일과 오늘 달성도를 단일 API로 통합 반환

### DIFF
--- a/backend/grit/src/main/java/grit/domain/todo/controller/TodoController.java
+++ b/backend/grit/src/main/java/grit/domain/todo/controller/TodoController.java
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.List;
 
-@Tag(name = "Todo", description = "투두 관련 API")
+@Tag(name = "Todo", descripti\on = "투두 관련 API")
 @RestController
 @RequiredArgsConstructor
 @Validated
@@ -159,7 +159,7 @@ public class TodoController {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "403", description = "다른 사용자 ID", content = @Content)
     })
-    @GetMapping("/api/users/{userId}/todos/achievement/last-7-days")
+    @GetMapping("/api/users/{userId}/todos/achievement")
     public ResponseEntity<AchievementOverviewResponseDTO> getLast7DaysAchievement(
             @AuthenticationPrincipal MemberPrincipal principal,
             @Parameter(description = "사용자 ID (PK)", example = "1") @PathVariable Long userId) {

--- a/backend/grit/src/main/java/grit/domain/todo/controller/TodoController.java
+++ b/backend/grit/src/main/java/grit/domain/todo/controller/TodoController.java
@@ -2,7 +2,7 @@ package grit.domain.todo.controller;
 
 import grit.domain.auth.infrastructure.jwt.MemberPrincipal;
 import grit.domain.todo.dto.CreateTodoRequestDTO;
-import grit.domain.todo.dto.DailyAchievementDTO;
+import grit.domain.todo.dto.AchievementOverviewResponseDTO;
 import grit.domain.todo.dto.MoveTodoDueDateRequestDTO;
 import grit.domain.todo.dto.SetTodoDoneRequestDTO;
 import grit.domain.todo.dto.TodoResponseDTO;
@@ -154,17 +154,17 @@ public class TodoController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "지난 7일간 일별 달성도 (본인만)", description = "오늘을 제외한 지난 7일간의 일별 투두 달성도입니다.")
+    @Operation(summary = "최근 달성도 조회 (본인만)", description = "오늘을 제외한 지난 7일간 일별 달성도와 오늘 달성도를 함께 반환합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "403", description = "다른 사용자 ID", content = @Content)
     })
     @GetMapping("/api/users/{userId}/todos/achievement/last-7-days")
-    public ResponseEntity<List<DailyAchievementDTO>> getLast7DaysAchievement(
+    public ResponseEntity<AchievementOverviewResponseDTO> getLast7DaysAchievement(
             @AuthenticationPrincipal MemberPrincipal principal,
             @Parameter(description = "사용자 ID (PK)", example = "1") @PathVariable Long userId) {
         MemberSelfAssert.assertSameMember(principal, userId);
-        List<DailyAchievementDTO> achievements = todoService.getLast7DaysAchievement(userId);
+        AchievementOverviewResponseDTO achievements = todoService.getLast7DaysAchievement(userId);
         return ResponseEntity.ok(achievements);
     }
 }

--- a/backend/grit/src/main/java/grit/domain/todo/dto/AchievementOverviewResponseDTO.java
+++ b/backend/grit/src/main/java/grit/domain/todo/dto/AchievementOverviewResponseDTO.java
@@ -1,0 +1,13 @@
+package grit.domain.todo.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AchievementOverviewResponseDTO {
+    private List<DailyAchievementDTO> last7Days;
+    private DailyAchievementDTO today;
+}

--- a/backend/grit/src/main/java/grit/domain/todo/service/TodoService.java
+++ b/backend/grit/src/main/java/grit/domain/todo/service/TodoService.java
@@ -6,6 +6,7 @@ import grit.domain.group.repository.MemberGroupRepository;
 import grit.domain.member.entity.Member;
 import grit.domain.member.repository.MemberRepository;
 import grit.domain.todo.dto.CreateTodoRequestDTO;
+import grit.domain.todo.dto.AchievementOverviewResponseDTO;
 import grit.domain.todo.dto.DailyAchievementDTO;
 import grit.domain.todo.dto.MoveTodoDueDateRequestDTO;
 import grit.domain.todo.dto.SetTodoDoneRequestDTO;
@@ -188,19 +189,19 @@ public class TodoService {
         return todo;
     }
 
-    public List<DailyAchievementDTO> getLast7DaysAchievement(Long userId) {
+    public AchievementOverviewResponseDTO getLast7DaysAchievement(Long userId) {
         LocalDate today = LocalDate.now();
-        LocalDate from = today.minusDays(7);
-        LocalDate to = today.minusDays(1);
+        LocalDate last7DaysFrom = today.minusDays(7);
+        LocalDate last7DaysTo = today.minusDays(1);
 
-        List<Todo> todos = todoRepository.findByOwnerIdAndDueDateBetween(userId, from, to);
+        List<Todo> todos = todoRepository.findByOwnerIdAndDueDateBetween(userId, last7DaysFrom, today);
 
         Map<LocalDate, List<Todo>> todosByDate = todos.stream()
                 .collect(Collectors.groupingBy(Todo::getDueDate));
 
-        List<DailyAchievementDTO> result = new ArrayList<>();
+        List<DailyAchievementDTO> last7Days = new ArrayList<>();
 
-        for (LocalDate date = from; !date.isAfter(to); date = date.plusDays(1)) {
+        for (LocalDate date = last7DaysFrom; !date.isAfter(last7DaysTo); date = date.plusDays(1)) {
             List<Todo> todosOfDay = todosByDate.getOrDefault(date, Collections.emptyList());
 
             long total = todosOfDay.size();
@@ -209,12 +210,22 @@ public class TodoService {
                     .count();
 
             if (total == 0) {
-                result.add(new DailyAchievementDTO(date, null, null, null));
+                last7Days.add(new DailyAchievementDTO(date, null, null, null));
             } else {
-                result.add(new DailyAchievementDTO(date, total, done));
+                last7Days.add(new DailyAchievementDTO(date, total, done));
             }
         }
 
-        return result;
+        List<Todo> todayTodos = todosByDate.getOrDefault(today, Collections.emptyList());
+        long todayTotal = todayTodos.size();
+        long todayDone = todayTodos.stream()
+                .filter(Todo::isDone)
+                .count();
+
+        DailyAchievementDTO todayAchievement = (todayTotal == 0)
+                ? new DailyAchievementDTO(today, null, null, null)
+                : new DailyAchievementDTO(today, todayTotal, todayDone);
+
+        return new AchievementOverviewResponseDTO(last7Days, todayAchievement);
     }
 }


### PR DESCRIPTION
# 변경점 👍
- 달성도 조회 응답을 확장해, 지난 7일 기록과 오늘 기록을 한 번에 받을 수 있게 변경
- 기존 단일 리스트 반환 방식에서, 기간별 목록 + 오늘 요약을 함께 담는 구조로 개선
- 조회 기간 계산 로직을 조정해 오늘 데이터까지 포함해서 집계하도록 업데이트