### PR TITLE
refactor: todo 관련 userId path variable 제거

### DIFF
--- a/backend/grit/src/main/java/grit/domain/todo/controller/TodoCategoryController.java
+++ b/backend/grit/src/main/java/grit/domain/todo/controller/TodoCategoryController.java
@@ -5,7 +5,6 @@ import grit.domain.todo.dto.CreateTodoCategoryRequestDto;
 import grit.domain.todo.dto.ReorderTodoCategoriesRequestDto;
 import grit.domain.todo.dto.TodoCategoryResponseDto;
 import grit.domain.todo.service.TodoCategoryService;
-import grit.global.security.MemberSelfAssert;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -28,12 +27,10 @@ public class TodoCategoryController {
     private final TodoCategoryService todoCategoryService;
 
     @Operation(summary = "내 투두 카테고리 목록", description = "사용자가 등록한 투두 카테고리를 표시 순서(sortOrder)대로 조회합니다.")
-    @GetMapping("/api/users/{userId}/todo-categories")
+    @GetMapping("/api/members/me/todo-categories")
     public ResponseEntity<List<TodoCategoryResponseDto>> list(
-            @AuthenticationPrincipal MemberPrincipal principal,
-            @Parameter(description = "사용자 ID (PK)", example = "1") @PathVariable Long userId) {
-        MemberSelfAssert.assertSameMember(principal, userId);
-        return ResponseEntity.ok(todoCategoryService.findByUserId(userId));
+            @AuthenticationPrincipal MemberPrincipal principal) {
+        return ResponseEntity.ok(todoCategoryService.findByUserId(principal.id()));
     }
 
     @Operation(summary = "투두 카테고리 등록", description = "이름은 같은 사용자 내에서 중복될 수 없습니다. 수정 API는 없습니다.")
@@ -42,13 +39,11 @@ public class TodoCategoryController {
             @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content),
             @ApiResponse(responseCode = "409", description = "이름 중복", content = @Content)
     })
-    @PostMapping("/api/users/{userId}/todo-categories")
+    @PostMapping("/api/members/me/todo-categories")
     public ResponseEntity<TodoCategoryResponseDto> create(
             @AuthenticationPrincipal MemberPrincipal principal,
-            @Parameter(description = "사용자 ID (PK)", example = "1") @PathVariable Long userId,
             @Valid @RequestBody CreateTodoCategoryRequestDto request) {
-        MemberSelfAssert.assertSameMember(principal, userId);
-        TodoCategoryResponseDto created = todoCategoryService.create(userId, request);
+        TodoCategoryResponseDto created = todoCategoryService.create(principal.id(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
@@ -59,13 +54,11 @@ public class TodoCategoryController {
             @ApiResponse(responseCode = "403", description = "본인이 아님", content = @Content),
             @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
     })
-    @PatchMapping("/api/users/{userId}/todo-categories/reorder")
+    @PatchMapping("/api/members/me/todo-categories/reorder")
     public ResponseEntity<List<TodoCategoryResponseDto>> reorder(
             @AuthenticationPrincipal MemberPrincipal principal,
-            @Parameter(description = "사용자 ID (PK)", example = "1") @PathVariable Long userId,
             @Valid @RequestBody ReorderTodoCategoriesRequestDto request) {
-        MemberSelfAssert.assertSameMember(principal, userId);
-        List<TodoCategoryResponseDto> updated = todoCategoryService.reorder(userId, request);
+        List<TodoCategoryResponseDto> updated = todoCategoryService.reorder(principal.id(), request);
         return ResponseEntity.ok(updated);
     }
 
@@ -74,13 +67,11 @@ public class TodoCategoryController {
             @ApiResponse(responseCode = "204", description = "삭제 성공"),
             @ApiResponse(responseCode = "404", description = "카테고리 없음", content = @Content)
     })
-    @DeleteMapping("/api/users/{userId}/todo-categories/{categoryId}")
+    @DeleteMapping("/api/members/me/todo-categories/{categoryId}")
     public ResponseEntity<Void> delete(
             @AuthenticationPrincipal MemberPrincipal principal,
-            @Parameter(description = "사용자 ID (PK)", example = "1") @PathVariable Long userId,
             @Parameter(description = "카테고리 ID", example = "1") @PathVariable Long categoryId) {
-        MemberSelfAssert.assertSameMember(principal, userId);
-        todoCategoryService.delete(userId, categoryId);
+        todoCategoryService.delete(principal.id(), categoryId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/grit/src/main/java/grit/domain/todo/controller/TodoCategoryController.java
+++ b/backend/grit/src/main/java/grit/domain/todo/controller/TodoCategoryController.java
@@ -51,7 +51,6 @@ public class TodoCategoryController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "순서 저장 성공"),
             @ApiResponse(responseCode = "400", description = "ID 목록 불일치·중복", content = @Content),
-            @ApiResponse(responseCode = "403", description = "본인이 아님", content = @Content),
             @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
     })
     @PatchMapping("/api/members/me/todo-categories/reorder")

--- a/backend/grit/src/main/java/grit/domain/todo/controller/TodoController.java
+++ b/backend/grit/src/main/java/grit/domain/todo/controller/TodoController.java
@@ -38,7 +38,6 @@ public class TodoController {
     @Operation(summary = "내 주간 투두 목록", description = "로그인한 사용자 본인의 투두를 주 단위(월~일)로 페이지네이션 조회합니다. weekStartDate가 월요일이 아니면 해당 날짜가 포함된 주의 월요일로 보정합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "403", description = "다른 사용자 ID로 조회 시도", content = @Content)
     })
     @GetMapping("/api/members/me/todos")
     public ResponseEntity<WeeklyTodosPageResponseDTO> findByUserId(
@@ -77,7 +76,6 @@ public class TodoController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "투두 생성 성공"),
             @ApiResponse(responseCode = "400", description = "입력 검증 실패", content = @Content),
-            @ApiResponse(responseCode = "403", description = "본인이 아님", content = @Content),
             @ApiResponse(responseCode = "404", description = "사용자·카테고리 없음", content = @Content)
     })
     @PostMapping("/api/members/me/todos")
@@ -152,7 +150,6 @@ public class TodoController {
     @Operation(summary = "최근 달성도 조회 (본인만)", description = "오늘을 제외한 지난 7일간 일별 달성도와 오늘 달성도를 함께 반환합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "403", description = "다른 사용자 ID", content = @Content)
     })
     @GetMapping("/api/members/me/todos/achievement")
     public ResponseEntity<AchievementOverviewResponseDTO> getLast7DaysAchievement(

--- a/backend/grit/src/main/java/grit/domain/todo/controller/TodoController.java
+++ b/backend/grit/src/main/java/grit/domain/todo/controller/TodoController.java
@@ -10,7 +10,6 @@ import grit.domain.todo.dto.UpdateTodoRequestDTO;
 import grit.domain.todo.dto.WeeklyTodosPageResponseDTO;
 import grit.domain.todo.entity.Todo;
 import grit.domain.todo.service.TodoService;
-import grit.global.security.MemberSelfAssert;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -41,19 +40,17 @@ public class TodoController {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "403", description = "다른 사용자 ID로 조회 시도", content = @Content)
     })
-    @GetMapping("/api/users/{userId}/todos")
+    @GetMapping("/api/members/me/todos")
     public ResponseEntity<WeeklyTodosPageResponseDTO> findByUserId(
             @AuthenticationPrincipal MemberPrincipal principal,
-            @Parameter(description = "사용자 ID (PK), 반드시 로그인 사용자와 동일", example = "1") @PathVariable Long userId,
             @Parameter(description = "조회 기준 날짜(해당 주 월~일 조회). 미입력 시 오늘 날짜 사용", example = "2026-04-21")
             @RequestParam(required = false) LocalDate weekStartDate,
             @Parameter(description = "페이지 번호(0부터 시작)", example = "0")
             @RequestParam(defaultValue = "0") @Min(value = 0, message = "page는 0 이상이어야 합니다.") int page,
             @Parameter(description = "페이지 크기", example = "20")
             @RequestParam(defaultValue = "20") @Min(value = 1, message = "size는 1 이상이어야 합니다.") int size) {
-        MemberSelfAssert.assertSameMember(principal, userId);
         LocalDate baseDate = weekStartDate != null ? weekStartDate : LocalDate.now();
-        WeeklyTodosPageResponseDTO response = todoService.findByUserIdWeekly(userId, baseDate, page, size);
+        WeeklyTodosPageResponseDTO response = todoService.findByUserIdWeekly(principal.id(), baseDate, page, size);
         return ResponseEntity.ok(response);
     }
 
@@ -83,13 +80,11 @@ public class TodoController {
             @ApiResponse(responseCode = "403", description = "본인이 아님", content = @Content),
             @ApiResponse(responseCode = "404", description = "사용자·카테고리 없음", content = @Content)
     })
-    @PostMapping("/api/users/{userId}/todos")
+    @PostMapping("/api/members/me/todos")
     public ResponseEntity<TodoResponseDTO> create(
             @AuthenticationPrincipal MemberPrincipal principal,
-            @Parameter(description = "사용자 ID (PK)", example = "1") @PathVariable Long userId,
             @Valid @RequestBody CreateTodoRequestDTO request) {
-        MemberSelfAssert.assertSameMember(principal, userId);
-        Todo todo = todoService.create(userId, request);
+        Todo todo = todoService.create(principal.id(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(TodoResponseDTO.from(todo));
     }
 
@@ -99,7 +94,7 @@ public class TodoController {
             @ApiResponse(responseCode = "403", description = "본인의 투두만 수정할 수 있음", content = @Content),
             @ApiResponse(responseCode = "404", description = "투두를 찾을 수 없음", content = @Content)
     })
-    @PutMapping("/api/todos/{todoId}")
+    @PutMapping("/api/members/me/todos/{todoId}")
     public ResponseEntity<TodoResponseDTO> update(
             @AuthenticationPrincipal MemberPrincipal principal,
             @Parameter(description = "투두 ID (PK)", example = "1") @PathVariable Long todoId,
@@ -115,7 +110,7 @@ public class TodoController {
             @ApiResponse(responseCode = "403", description = "본인의 투두만 수정할 수 있음", content = @Content),
             @ApiResponse(responseCode = "404", description = "투두를 찾을 수 없음", content = @Content)
     })
-    @PatchMapping("/api/todos/{todoId}/due-date")
+    @PatchMapping("/api/members/me/todos/{todoId}/due-date")
     public ResponseEntity<TodoResponseDTO> moveDueDate(
             @AuthenticationPrincipal MemberPrincipal principal,
             @Parameter(description = "투두 ID (PK)", example = "1") @PathVariable Long todoId,
@@ -131,7 +126,7 @@ public class TodoController {
             @ApiResponse(responseCode = "403", description = "본인의 투두만 수정할 수 있음", content = @Content),
             @ApiResponse(responseCode = "404", description = "투두를 찾을 수 없음", content = @Content)
     })
-    @PatchMapping("/api/todos/{todoId}/done")
+    @PatchMapping("/api/members/me/todos/{todoId}/done")
     public ResponseEntity<TodoResponseDTO> setDone(
             @AuthenticationPrincipal MemberPrincipal principal,
             @Parameter(description = "투두 ID (PK)", example = "1") @PathVariable Long todoId,
@@ -146,7 +141,7 @@ public class TodoController {
             @ApiResponse(responseCode = "403", description = "본인의 투두만 삭제할 수 있음", content = @Content),
             @ApiResponse(responseCode = "404", description = "투두를 찾을 수 없음", content = @Content)
     })
-    @DeleteMapping("/api/todos/{todoId}")
+    @DeleteMapping("/api/members/me/todos/{todoId}")
     public ResponseEntity<Void> delete(
             @AuthenticationPrincipal MemberPrincipal principal,
             @Parameter(description = "투두 ID (PK)", example = "1") @PathVariable Long todoId) {
@@ -159,12 +154,10 @@ public class TodoController {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "403", description = "다른 사용자 ID", content = @Content)
     })
-    @GetMapping("/api/users/{userId}/todos/achievement")
+    @GetMapping("/api/members/me/todos/achievement")
     public ResponseEntity<AchievementOverviewResponseDTO> getLast7DaysAchievement(
-            @AuthenticationPrincipal MemberPrincipal principal,
-            @Parameter(description = "사용자 ID (PK)", example = "1") @PathVariable Long userId) {
-        MemberSelfAssert.assertSameMember(principal, userId);
-        AchievementOverviewResponseDTO achievements = todoService.getLast7DaysAchievement(userId);
+            @AuthenticationPrincipal MemberPrincipal principal) {
+        AchievementOverviewResponseDTO achievements = todoService.getLast7DaysAchievement(principal.id());
         return ResponseEntity.ok(achievements);
     }
 }

--- a/backend/grit/src/main/resources/static/todo.js
+++ b/backend/grit/src/main/resources/static/todo.js
@@ -38,7 +38,6 @@ function escapeHtml(str) {
 
 async function fetchTodos() {
     const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/members/me/todos`);
-    if (response.status === 403) throw new Error('본인 계정의 투두만 볼 수 있습니다. (로그인·member_id 불일치)');
     if (!response.ok) throw new Error('투두 목록을 불러오지 못했습니다.');
     const payload = await response.json();
     // 백엔드가 페이지 객체(weekly)로 내려주는 최신 스펙과 단순 배열 응답 모두 호환
@@ -49,14 +48,12 @@ async function fetchTodos() {
 
 async function fetchAchievement() {
     const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/members/me/todos/achievement`);
-    if (response.status === 403) throw new Error('본인 계정의 달성도만 볼 수 있습니다.');
     if (!response.ok) throw new Error('달성도를 불러오지 못했습니다.');
     return response.json();
 }
 
 async function fetchTodoCategories() {
     const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/members/me/todo-categories`);
-    if (response.status === 403) throw new Error('본인 카테고리만 볼 수 있습니다.');
     if (!response.ok) throw new Error('카테고리 목록을 불러오지 못했습니다.');
     return response.json();
 }

--- a/backend/grit/src/main/resources/static/todo.js
+++ b/backend/grit/src/main/resources/static/todo.js
@@ -1,10 +1,6 @@
 // ────────────────────────────────────────
-// Todo JS — /api/users/{userId}/todos
+// Todo JS — /api/members/me/todos
 // ────────────────────────────────────────
-
-function getMemberId() {
-    return localStorage.getItem('member_id');
-}
 
 // 인증 확인
 function checkAuth() {
@@ -41,8 +37,7 @@ function escapeHtml(str) {
 // ────────────────────────────────────────
 
 async function fetchTodos() {
-    const userId = getMemberId();
-    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/users/${userId}/todos`);
+    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/members/me/todos`);
     if (response.status === 403) throw new Error('본인 계정의 투두만 볼 수 있습니다. (로그인·member_id 불일치)');
     if (!response.ok) throw new Error('투두 목록을 불러오지 못했습니다.');
     const payload = await response.json();
@@ -53,24 +48,21 @@ async function fetchTodos() {
 }
 
 async function fetchAchievement() {
-    const userId = getMemberId();
-    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/users/${userId}/todos/achievement`);
+    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/members/me/todos/achievement`);
     if (response.status === 403) throw new Error('본인 계정의 달성도만 볼 수 있습니다.');
     if (!response.ok) throw new Error('달성도를 불러오지 못했습니다.');
     return response.json();
 }
 
 async function fetchTodoCategories() {
-    const userId = getMemberId();
-    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/users/${userId}/todo-categories`);
+    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/members/me/todo-categories`);
     if (response.status === 403) throw new Error('본인 카테고리만 볼 수 있습니다.');
     if (!response.ok) throw new Error('카테고리 목록을 불러오지 못했습니다.');
     return response.json();
 }
 
 async function createTodoCategory(name) {
-    const userId = getMemberId();
-    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/users/${userId}/todo-categories`, {
+    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/members/me/todo-categories`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name })
@@ -87,9 +79,8 @@ async function createTodoCategory(name) {
 }
 
 async function deleteTodoCategory(categoryId) {
-    const userId = getMemberId();
     const response = await apiFetch(
-        `${API_CONFIG.BASE_URL}/api/users/${userId}/todo-categories/${categoryId}`,
+        `${API_CONFIG.BASE_URL}/api/members/me/todo-categories/${categoryId}`,
         { method: 'DELETE' }
     );
     if (!response.ok) {
@@ -100,8 +91,7 @@ async function deleteTodoCategory(categoryId) {
 
 /** @param {number[]} categoryIds 본인 카테고리 ID 전체를 원하는 순서대로 */
 async function reorderTodoCategories(categoryIds) {
-    const userId = getMemberId();
-    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/users/${userId}/todo-categories/reorder`, {
+    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/members/me/todo-categories/reorder`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ categoryIds })
@@ -132,11 +122,10 @@ async function fetchGroupTodos(groupCode, userId) {
 }
 
 async function createTodo(content, categoryId, dueDate) {
-    const userId = getMemberId();
     const body = { content, dueDate };
     if (categoryId) body.categoryId = categoryId;
 
-    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/users/${userId}/todos`, {
+    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/members/me/todos`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body)
@@ -149,7 +138,7 @@ async function createTodo(content, categoryId, dueDate) {
 }
 
 async function updateTodo(todoId, patch) {
-    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/todos/${todoId}`, {
+    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/members/me/todos/${todoId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(patch)
@@ -173,7 +162,7 @@ async function handlePatchResponse(response, defaultMsg) {
 
 /** 마감일만 변경 (캘린더 드래그앤드롭 등). body: { dueDate: 'YYYY-MM-DD' } */
 async function patchTodoDueDate(todoId, dueDate) {
-    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/todos/${todoId}/due-date`, {
+    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/members/me/todos/${todoId}/due-date`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ dueDate })
@@ -183,7 +172,7 @@ async function patchTodoDueDate(todoId, dueDate) {
 
 /** 완료 체크/해제만. body: { isDone: boolean } */
 async function patchTodoDone(todoId, isDone) {
-    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/todos/${todoId}/done`, {
+    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/members/me/todos/${todoId}/done`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ isDone })
@@ -192,7 +181,7 @@ async function patchTodoDone(todoId, isDone) {
 }
 
 async function deleteTodo(todoId) {
-    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/todos/${todoId}`, {
+    const response = await apiFetch(`${API_CONFIG.BASE_URL}/api/members/me/todos/${todoId}`, {
         method: 'DELETE'
     });
     if (response.status === 403) throw new Error('본인의 투두만 삭제할 수 있습니다.');


### PR DESCRIPTION
# 변경점 👍
- Todo/TodoCategory API에서 `userId` path variable 제거
- 경로를 `/api/users/{userId}/...` 에서 `/api/members/me/...` 형태로 통일
- 컨트롤러에서 사용자 식별을 URL이 아닌 `@AuthenticationPrincipal`(`principal.id()`) 기준으로 변경
- 프론트 `todo.js`의 Todo/Category/Achievement 호출 경로를 신규 `members/me` 엔드포인트로 전면 반영
- 경로 변경 후 불필요해진 코드(미사용 `getMemberId`, 불필요 self-assert/import) 정리