### PR TITLE
refactor: 투두 API 경로 /members/me로 수정

### DIFF
--- a/frontend/src/apis/constants/endpoints.ts
+++ b/frontend/src/apis/constants/endpoints.ts
@@ -28,17 +28,13 @@ export const ENDPOINTS = {
     TOKEN: "/livekit/token",
   },
   TODO: {
-    BY_ID: (todoId: number) => `/api/todos/${todoId}`,
-    DONE: (todoId: number) => `/api/todos/${todoId}/done`,
-    DUE_DATE: (todoId: number) => `/api/todos/${todoId}/due-date`,
-    BY_USER: (userId: number) => `/api/users/${userId}/todos`,
-    ACHIEVEMENT_BY_USER: (userId: number) =>
-      `/api/users/${userId}/todos/achievement`,
-    CATEGORIES_BY_USER: (userId: number) =>
-      `/api/users/${userId}/todo-categories`,
-    CATEGORIES_BY_USER_CATEGORY: (userId: number, categoryId: number) =>
-      `/api/users/${userId}/todo-categories/${categoryId}`,
-    CATEGORIES_REORDER: (userId: number) =>
-      `/api/users/${userId}/todo-categories/reorder`,
+    BY_ID: (todoId: number) => `/api/members/me/todos/${todoId}`,
+    DONE: (todoId: number) => `/api/members/me/todos/${todoId}/done`,
+    DUE_DATE: (todoId: number) => `/api/members/me/todos/${todoId}/due-date`,
+    LIST: `/api/members/me/todos`,
+    ACHIEVEMENT: `/api/members/me/todos/achievement`,
+    CATEGORIES: `/api/members/me/todo-categories`,
+    CATEGORY_BY_ID: (categoryId: number) => `/api/members/me/todo-categories/${categoryId}`,
+    CATEGORIES_REORDER: `/api/members/me/todo-categories/reorder`,
   },
 } as const;

--- a/frontend/src/apis/domains/todo/api.ts
+++ b/frontend/src/apis/domains/todo/api.ts
@@ -15,41 +15,33 @@ import type {
 } from "@/apis/domains/todo/type";
 
 export const todoApi = {
-  getListByUserId: async (
-    userId: number,
+  getList: async (
     params?: TodoListByUserParams,
   ): Promise<TodoListByUserResponse> => {
     const response = await apiClient.get<TodoListByUserResponse>(
-      ENDPOINTS.TODO.BY_USER(userId),
+      ENDPOINTS.TODO.LIST,
       { params },
     );
     return response.data;
   },
 
-  getCategoriesByUserId: async (
-    userId: number,
-  ): Promise<TodoCategoryApiItem[]> => {
+  getCategories: async (): Promise<TodoCategoryApiItem[]> => {
     const response = await apiClient.get<TodoCategoryApiItem[]>(
-      ENDPOINTS.TODO.CATEGORIES_BY_USER(userId),
+      ENDPOINTS.TODO.CATEGORIES,
     );
     return response.data;
   },
 
-  getAchievementByUserId: async (
-    userId: number,
-  ): Promise<TodoAchievementResponse> => {
+  getAchievement: async (): Promise<TodoAchievementResponse> => {
     const response = await apiClient.get<TodoAchievementResponse>(
-      ENDPOINTS.TODO.ACHIEVEMENT_BY_USER(userId),
+      ENDPOINTS.TODO.ACHIEVEMENT,
     );
     return response.data;
   },
 
-  createTodo: async (
-    userId: number,
-    body: CreateTodoBody,
-  ): Promise<TodoApiItem> => {
+  createTodo: async (body: CreateTodoBody): Promise<TodoApiItem> => {
     const response = await apiClient.post<TodoApiItem>(
-      ENDPOINTS.TODO.BY_USER(userId),
+      ENDPOINTS.TODO.LIST,
       body,
     );
     return response.data;
@@ -93,28 +85,26 @@ export const todoApi = {
   },
 
   createCategory: async (
-    userId: number,
     body: CreateTodoCategoryBody,
   ): Promise<TodoCategoryApiItem> => {
     const response = await apiClient.post<TodoCategoryApiItem>(
-      ENDPOINTS.TODO.CATEGORIES_BY_USER(userId),
+      ENDPOINTS.TODO.CATEGORIES,
       body,
     );
     return response.data;
   },
 
-  deleteCategory: async (userId: number, categoryId: number): Promise<void> => {
+  deleteCategory: async (categoryId: number): Promise<void> => {
     await apiClient.delete(
-      ENDPOINTS.TODO.CATEGORIES_BY_USER_CATEGORY(userId, categoryId),
+      ENDPOINTS.TODO.CATEGORY_BY_ID(categoryId),
     );
   },
 
   reorderCategories: async (
-    userId: number,
     body: ReorderTodoCategoriesBody,
   ): Promise<TodoCategoryApiItem[]> => {
     const response = await apiClient.patch<TodoCategoryApiItem[]>(
-      ENDPOINTS.TODO.CATEGORIES_REORDER(userId),
+      ENDPOINTS.TODO.CATEGORIES_REORDER,
       body,
     );
     return response.data;

--- a/frontend/src/hooks/todo/useTodoData.ts
+++ b/frontend/src/hooks/todo/useTodoData.ts
@@ -6,8 +6,9 @@ import {
 } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { QUERY_KEYS } from "@/apis/constants/queryKeys";
-import { getStoredMember } from "@/apis/domains/auth/api";
 import { todoApi } from "@/apis/domains/todo/api";
+import { userApi } from "@/apis/domains/user/api";
+import { getAccessToken } from "@/utils/tokenStorage";
 import {
   DEFAULT_CATEGORIES,
   type Category,
@@ -27,7 +28,13 @@ export function useTodoData({
   size = 20,
 }: UseTodoDataOptions) {
   const queryClient = useQueryClient();
-  const userId = getStoredMember()?.id ?? null;
+  const accessToken = getAccessToken();
+  const { data: member } = useQuery({
+    queryKey: QUERY_KEYS.member.me,
+    queryFn: userApi.get,
+    enabled: accessToken != null,
+  });
+  const userId = member?.id ?? null;
 
   const {
     data: serverTodos = [],
@@ -39,7 +46,7 @@ export function useTodoData({
         ? QUERY_KEYS.todos.byUserWeek(userId, weekStartDate, page, size)
         : (["todos", "guest"] as const),
     queryFn: async () => {
-      const response = await todoApi.getListByUserId(userId!, {
+      const response = await todoApi.getList({
         weekStartDate,
         page,
         size,
@@ -62,7 +69,7 @@ export function useTodoData({
         ? QUERY_KEYS.todoCategories.byUser(userId)
         : (["todoCategories", "guest"] as const),
     queryFn: async () => {
-      const rows = await todoApi.getCategoriesByUserId(userId!);
+      const rows = await todoApi.getCategories();
       const sorted = [...rows].sort((a, b) => {
         const ao = a.sortOrder ?? 0;
         const bo = b.sortOrder ?? 0;

--- a/frontend/src/hooks/todo/useTodoMutations.ts
+++ b/frontend/src/hooks/todo/useTodoMutations.ts
@@ -58,7 +58,7 @@ export function useTodoMutations(options: {
 
   const createCategoryMutation = useMutation({
     mutationFn: ({ name, tempId: _tempId }: { name: string; tempId: string }) =>
-      todoApi.createCategory(userId!, { name }),
+      todoApi.createCategory({ name }),
     onMutate: async ({ name, tempId }) => {
       if (userId == null) return {};
       await queryClient.cancelQueries({
@@ -119,7 +119,7 @@ export function useTodoMutations(options: {
         categoryId: string;
       };
       tempId: string;
-    }) => todoApi.createTodo(userId!, buildCreateTodoBody(vars.item)),
+    }) => todoApi.createTodo(buildCreateTodoBody(vars.item)),
     onMutate: async ({ item, tempId }) => {
       if (userId == null) return {};
       await queryClient.cancelQueries({
@@ -365,7 +365,7 @@ export function useTodoMutations(options: {
       categoryId: number;
       categoryIdStr: string;
     }) => {
-      await todoApi.deleteCategory(userId!, categoryId);
+      await todoApi.deleteCategory(categoryId);
     },
     onMutate: async ({ categoryIdStr }) => {
       if (userId == null) return {};
@@ -414,7 +414,7 @@ export function useTodoMutations(options: {
   const reorderCategoriesMutation = useMutation({
     mutationFn: async ({ categoryIds }: { categoryIds: number[] }) => {
       const requestId = ++reorderRequestIdRef.current;
-      const data = await todoApi.reorderCategories(userId!, { categoryIds });
+      const data = await todoApi.reorderCategories({ categoryIds });
       return { data, requestId };
     },
     onMutate: async ({ categoryIds }) => {

--- a/frontend/src/pages/Home/components/AchievementCard.tsx
+++ b/frontend/src/pages/Home/components/AchievementCard.tsx
@@ -4,8 +4,9 @@ import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { Trophy, Settings } from "lucide-react";
 import { QUERY_KEYS } from "@/apis/constants/queryKeys";
-import { getStoredMember } from "@/apis/domains/auth/api";
 import { todoApi } from "@/apis/domains/todo/api";
+import { userApi } from "@/apis/domains/user/api";
+import { getAccessToken } from "@/utils/tokenStorage";
 import { PATHS } from "@/routes/path";
 
 const DAY_LABELS = ["일", "월", "화", "수", "목", "금", "토"] as const;
@@ -19,7 +20,13 @@ const EMPTY_WEEKLY_DATA = Array.from({ length: 7 }, (_, index) => {
 
 const AchievementCard: React.FC = () => {
   const navigate = useNavigate();
-  const userId = getStoredMember()?.id ?? null;
+  const accessToken = getAccessToken();
+  const { data: member } = useQuery({
+    queryKey: QUERY_KEYS.member.me,
+    queryFn: userApi.get,
+    enabled: accessToken != null,
+  });
+  const userId = member?.id ?? null;
 
   const { data, isLoading, isError } = useQuery({
     queryKey: QUERY_KEYS.todos.achievement(userId),
@@ -27,7 +34,7 @@ const AchievementCard: React.FC = () => {
       if (userId == null) {
         throw new Error("로그인 사용자 정보가 필요합니다.");
       }
-      return todoApi.getAchievementByUserId(userId);
+      return todoApi.getAchievement();
     },
     enabled: userId != null,
   });


### PR DESCRIPTION
# 변경점 👍
- 투두 API 엔드포인트를 백엔드 스펙에 맞게 `/api/members/me/*` 기준으로 정리
- `ENDPOINTS.TODO` 키명을 현재 의미에 맞게 정리 (`LIST`, `ACHIEVEMENT`, `CATEGORIES`, `CATEGORY_BY_ID`)
- `todoApi` 함수 시그니처에서 불필요한 `userId` 인자 제거 및 호출부 전면 반영
- 투두/카테고리/달성도 조회 함수명을 현재 동작 기준으로 리네이밍 (`getList`, `getCategories`, `getAchievement`)
- auth-storage` 의존 제거, `member.me` 조회 결과로 `userId` 결정하도록 변경
