### PR TITLE
refactor: 홈 화면 반응형 레이아웃 적용

### DIFF
--- a/frontend/src/components/SmallViewportNotice.tsx
+++ b/frontend/src/components/SmallViewportNotice.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
-const MIN_TABLET_WIDTH = 768;
+const MIN_TABLET_WIDTH = 700;
 
 interface SmallViewportNoticeProps {
   children: ReactNode;

--- a/frontend/src/components/SmallViewportNotice.tsx
+++ b/frontend/src/components/SmallViewportNotice.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
-const MIN_TABLET_WIDTH = 700;
+const MIN_TABLET_WIDTH = 768;
 
 interface SmallViewportNoticeProps {
   children: ReactNode;

--- a/frontend/src/pages/Home/components/AchievementCard.tsx
+++ b/frontend/src/pages/Home/components/AchievementCard.tsx
@@ -40,7 +40,7 @@ const AchievementCard: React.FC = () => {
     })) ?? EMPTY_WEEKLY_DATA;
 
   return (
-    <div className="w-1/2 h-64 bg-[#2E3039] rounded-2xl p-6 select-none">
+    <div className="w-full lg:w-1/2 h-64 bg-[#2E3039] rounded-2xl p-6 select-none">
       {/* 오늘의 달성도 섹션 */}
       <div className="mb-6">
         <div className="mb-4 flex items-center justify-between">

--- a/frontend/src/pages/Home/components/GroupSection/GroupSection.tsx
+++ b/frontend/src/pages/Home/components/GroupSection/GroupSection.tsx
@@ -23,7 +23,7 @@ export default function GroupSection() {
 
   return (
     <section className="w-auto h-auto bg-[#2E3039] rounded-3xl p-8">
-      <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-2 gap-8 md:grid-cols-3 lg:grid-cols-4 [@media(min-width:768px)_and_(max-width:1023px)]:justify-items-center [@media(min-width:768px)_and_(max-width:1023px)]:[&>*]:w-full [@media(min-width:768px)_and_(max-width:1023px)]:[&>*]:max-w-[clamp(180px,24vw,240px)]">
         <div className="flex flex-col gap-8">
           <Button
             icon={<Plus size={32} />}

--- a/frontend/src/pages/Home/components/ProfileCard.tsx
+++ b/frontend/src/pages/Home/components/ProfileCard.tsx
@@ -44,7 +44,7 @@ const ProfileCard = ({
   const goalTimeLabel = member?.weeklyStudyTimeGoal?.trim() || "미설정";
 
   return (
-    <div className="w-1/2 h-64 bg-green-dark rounded-2xl p-6">
+    <div className="w-full lg:w-1/2 h-64 bg-green-dark rounded-2xl p-6">
       <div className="mb-4 flex justify-end">
         <button
           type="button"

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -33,8 +33,8 @@ const HomePage = () => {
             </div>
           </aside>
           <div className="flex-1 overflow-y-auto overscroll-contain">
-            <div className="mx-auto w-full max-w-[1180px] px-8 pb-16">
-              <div className="mt-18 flex items-center justify-center gap-8">
+            <div className="mx-auto w-full max-w-[1180px] px-16 pb-16">
+              <div className="mt-18 flex flex-col-reverse lg:flex-row items-center justify-center gap-8">
                 <Achievement />
                 <ProfileCard
                   initialSettingsOpen={shouldOpenProfileSetup}


### PR DESCRIPTION
# 변경점 👍
- **1024px 이상**  
  - 상단 카드가 가로 2열로 표시됨 (`오늘의 달성도 → 내 프로필`)  
  - 그룹 카드는 한 줄에 **4개**

- **768px ~ 1023px**  
  - 상단 카드가 세로 1열로 표시됨 (`내 프로필 → 오늘의 달성도`)  
  - 그룹 카드는 화면이 줄어들면서 **3개 → 2개**로 전환됨  
  - 이 구간에서 좌우 여백은 동일하게 유지됨

- **그룹 카드 최소 개수 보장**  
  - 화면이 더 줄어도 그룹 영역은 **최소 2개 열 유지**  
  - 1개 열로 떨어지지 않음