### PR TITLE
feat: 투두 목록 조회를 startDate, dayCount 기간 조회로 변경

### DIFF
--- a/backend/grit/src/main/java/grit/domain/todo/controller/TodoController.java
+++ b/backend/grit/src/main/java/grit/domain/todo/controller/TodoController.java
@@ -6,7 +6,7 @@ import grit.domain.todo.dto.MoveTodoDueDateRequestDTO;
 import grit.domain.todo.dto.SetTodoDoneRequestDTO;
 import grit.domain.todo.dto.TodoResponseDTO;
 import grit.domain.todo.dto.UpdateTodoRequestDTO;
-import grit.domain.todo.dto.WeeklyTodosPageResponseDTO;
+import grit.domain.todo.dto.TodoRangeResponseDTO;
 import grit.domain.todo.entity.Todo;
 import grit.domain.todo.service.TodoService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,6 +24,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
@@ -35,6 +36,7 @@ import java.util.List;
 @Validated
 public class TodoController {
     private final TodoService todoService;
+    private final Clock clock;
 
     @Operation(
             summary = "내 투두 목록 (기간 조회)",
@@ -49,7 +51,7 @@ public class TodoController {
             @ApiResponse(responseCode = "400", description = "dayCount 범위 오류 등", content = @Content),
     })
     @GetMapping("/api/members/me/todos")
-    public ResponseEntity<WeeklyTodosPageResponseDTO> findByUserId(
+    public ResponseEntity<TodoRangeResponseDTO> findByUserId(
             @AuthenticationPrincipal MemberPrincipal principal,
             @Parameter(description = "조회 구간 첫 날(포함)", example = "2026-05-15")
             @RequestParam(required = false) LocalDate startDate,
@@ -60,10 +62,10 @@ public class TodoController {
             Integer dayCount) {
         LocalDate resolvedStartDate = startDate != null
                 ? startDate
-                : LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+                : LocalDate.now(clock).with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
         int resolvedDayCount = dayCount != null ? dayCount : 7;
 
-        WeeklyTodosPageResponseDTO response = todoService.findByUserIdInRange(
+        TodoRangeResponseDTO response = todoService.findByUserIdInRange(
                 principal.id(), resolvedStartDate, resolvedDayCount);
         return ResponseEntity.ok(response);
     }

--- a/backend/grit/src/main/java/grit/domain/todo/controller/TodoController.java
+++ b/backend/grit/src/main/java/grit/domain/todo/controller/TodoController.java
@@ -1,5 +1,4 @@
 package grit.domain.todo.controller;
-
 import grit.domain.auth.infrastructure.jwt.MemberPrincipal;
 import grit.domain.todo.dto.CreateTodoRequestDTO;
 import grit.domain.todo.dto.AchievementOverviewResponseDTO;
@@ -17,6 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -24,8 +24,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
 @Tag(name = "Todo", description = "투두 관련 API")
@@ -35,21 +36,35 @@ import java.util.List;
 public class TodoController {
     private final TodoService todoService;
 
-    @Operation(summary = "내 주간 투두 목록", description = "로그인한 사용자 본인의 투두를 주 단위(월~일)로 페이지네이션 조회합니다. weekStartDate가 월요일이 아니면 해당 날짜가 포함된 주의 월요일로 보정합니다.")
+    @Operation(
+            summary = "내 투두 목록 (기간 조회)",
+            description = """
+                    로그인한 사용자 본인의 투두를 dueDate 기준으로 조회합니다. 조회 구간 내 투두를 한 번에 모두 반환합니다.
+                    조회 구간: [startDate, startDate + (dayCount - 1)일] (양끝 포함).
+                    startDate·dayCount 미입력 시 이번 주 월요일부터 7일간 조회합니다.
+                    """
+    )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "dayCount 범위 오류 등", content = @Content),
     })
     @GetMapping("/api/members/me/todos")
     public ResponseEntity<WeeklyTodosPageResponseDTO> findByUserId(
             @AuthenticationPrincipal MemberPrincipal principal,
-            @Parameter(description = "조회 기준 날짜(해당 주 월~일 조회). 미입력 시 오늘 날짜 사용", example = "2026-04-21")
-            @RequestParam(required = false) LocalDate weekStartDate,
-            @Parameter(description = "페이지 번호(0부터 시작)", example = "0")
-            @RequestParam(defaultValue = "0") @Min(value = 0, message = "page는 0 이상이어야 합니다.") int page,
-            @Parameter(description = "페이지 크기", example = "20")
-            @RequestParam(defaultValue = "20") @Min(value = 1, message = "size는 1 이상이어야 합니다.") int size) {
-        LocalDate baseDate = weekStartDate != null ? weekStartDate : LocalDate.now();
-        WeeklyTodosPageResponseDTO response = todoService.findByUserIdWeekly(principal.id(), baseDate, page, size);
+            @Parameter(description = "조회 구간 첫 날(포함)", example = "2026-05-15")
+            @RequestParam(required = false) LocalDate startDate,
+            @Parameter(description = "조회 일수(1~7). startDate와 함께 사용", example = "5")
+            @RequestParam(required = false)
+            @Min(value = 1, message = "dayCount는 1 이상이어야 합니다.")
+            @Max(value = 7, message = "dayCount는 7 이하여야 합니다.")
+            Integer dayCount) {
+        LocalDate resolvedStartDate = startDate != null
+                ? startDate
+                : LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        int resolvedDayCount = dayCount != null ? dayCount : 7;
+
+        WeeklyTodosPageResponseDTO response = todoService.findByUserIdInRange(
+                principal.id(), resolvedStartDate, resolvedDayCount);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/grit/src/main/java/grit/domain/todo/dto/TodoRangeResponseDTO.java
+++ b/backend/grit/src/main/java/grit/domain/todo/dto/TodoRangeResponseDTO.java
@@ -1,13 +1,15 @@
 package grit.domain.todo.dto;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
 import java.time.LocalDate;
 import java.util.List;
 
 @Getter
 @AllArgsConstructor
-public class WeeklyTodosPageResponseDTO {
+public class TodoRangeResponseDTO {
     @Schema(description = "조회 구간 첫 날(포함)", example = "2026-05-15")
     private LocalDate startDate;
 

--- a/backend/grit/src/main/java/grit/domain/todo/dto/WeeklyTodosPageResponseDTO.java
+++ b/backend/grit/src/main/java/grit/domain/todo/dto/WeeklyTodosPageResponseDTO.java
@@ -1,36 +1,25 @@
 package grit.domain.todo.dto;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
 import java.time.LocalDate;
 import java.util.List;
 
 @Getter
 @AllArgsConstructor
 public class WeeklyTodosPageResponseDTO {
-    @Schema(description = "조회한 주의 시작일(월요일)", example = "2026-04-20")
-    private LocalDate weekStartDate;
+    @Schema(description = "조회 구간 첫 날(포함)", example = "2026-05-15")
+    private LocalDate startDate;
 
-    @Schema(description = "조회한 주의 종료일(일요일)", example = "2026-04-26")
-    private LocalDate weekEndDate;
+    @Schema(description = "조회 구간 마지막 날(포함)", example = "2026-05-19")
+    private LocalDate endDate;
 
-    @Schema(description = "현재 페이지 번호(0부터 시작)", example = "0")
-    private int page;
+    @Schema(description = "조회 일수", example = "5")
+    private int dayCount;
 
-    @Schema(description = "페이지 크기", example = "20")
-    private int size;
+    @Schema(description = "조회 구간 내 투두 총 개수", example = "37")
+    private long totalCount;
 
-    @Schema(description = "전체 항목 수", example = "37")
-    private long totalElements;
-
-    @Schema(description = "전체 페이지 수", example = "2")
-    private int totalPages;
-
-    @Schema(description = "다음 페이지 존재 여부", example = "true")
-    private boolean hasNext;
-
-    @Schema(description = "현재 페이지 투두 목록")
+    @Schema(description = "투두 목록 (조회 구간 전체)")
     private List<TodoResponseDTO> todos;
 }

--- a/backend/grit/src/main/java/grit/domain/todo/repository/TodoRepository.java
+++ b/backend/grit/src/main/java/grit/domain/todo/repository/TodoRepository.java
@@ -1,13 +1,9 @@
 package grit.domain.todo.repository;
-
 import grit.domain.todo.entity.Todo;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -31,19 +27,12 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
                         c.sortOrder ASC,
                         t.content ASC,
                         t.id ASC
-                    """,
-            countQuery = """
-                    SELECT COUNT(t) FROM Todo t
-                    WHERE t.owner.id = :ownerId
-                      AND t.dueDate >= :from
-                      AND t.dueDate <= :to
                     """
     )
-    Page<Todo> findByOwnerIdAndDueDateBetweenWithRelations(
+    List<Todo> findByOwnerIdAndDueDateBetweenWithRelations(
             @Param("ownerId") Long ownerId,
             @Param("from") LocalDate from,
-            @Param("to") LocalDate to,
-            Pageable pageable
+            @Param("to") LocalDate to
     );
 
     @Query("SELECT DISTINCT t FROM Todo t JOIN FETCH t.owner LEFT JOIN FETCH t.category WHERE t.id = :id")

--- a/backend/grit/src/main/java/grit/domain/todo/service/TodoService.java
+++ b/backend/grit/src/main/java/grit/domain/todo/service/TodoService.java
@@ -11,7 +11,7 @@ import grit.domain.todo.dto.MoveTodoDueDateRequestDTO;
 import grit.domain.todo.dto.SetTodoDoneRequestDTO;
 import grit.domain.todo.dto.TodoResponseDTO;
 import grit.domain.todo.dto.UpdateTodoRequestDTO;
-import grit.domain.todo.dto.WeeklyTodosPageResponseDTO;
+import grit.domain.todo.dto.TodoRangeResponseDTO;
 import grit.domain.todo.entity.Todo;
 import grit.domain.todo.entity.TodoCategory;
 import grit.domain.todo.repository.TodoCategoryRepository;
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 import java.text.Collator;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,8 +44,9 @@ public class TodoService {
     private final MemberRepository memberRepository;
     private final GroupRepository groupRepository;
     private final MemberGroupRepository memberGroupRepository;
+    private final Clock clock;
 
-    public WeeklyTodosPageResponseDTO findByUserIdInRange(Long userId, LocalDate startDate, int dayCount) {
+    public TodoRangeResponseDTO findByUserIdInRange(Long userId, LocalDate startDate, int dayCount) {
         LocalDate endDate = startDate.plusDays(dayCount - 1L);
 
         List<TodoResponseDTO> todos = todoRepository
@@ -53,7 +55,7 @@ public class TodoService {
                 .map(TodoResponseDTO::from)
                 .toList();
 
-        return new WeeklyTodosPageResponseDTO(
+        return new TodoRangeResponseDTO(
                 startDate,
                 endDate,
                 dayCount,
@@ -176,7 +178,7 @@ public class TodoService {
     }
 
     public AchievementOverviewResponseDTO getLast7DaysAchievement(Long userId) {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(clock);
         LocalDate last7DaysFrom = today.minusDays(7);
         LocalDate last7DaysTo = today.minusDays(1);
 

--- a/backend/grit/src/main/java/grit/domain/todo/service/TodoService.java
+++ b/backend/grit/src/main/java/grit/domain/todo/service/TodoService.java
@@ -1,5 +1,4 @@
 package grit.domain.todo.service;
-
 import grit.domain.group.entity.Group;
 import grit.domain.group.repository.GroupRepository;
 import grit.domain.group.repository.MemberGroupRepository;
@@ -18,17 +17,12 @@ import grit.domain.todo.entity.TodoCategory;
 import grit.domain.todo.repository.TodoCategoryRepository;
 import grit.domain.todo.repository.TodoRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
-
 import java.text.Collator;
 import java.time.LocalDate;
-import java.time.DayOfWeek;
-import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -41,7 +35,6 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class TodoService {
-    /** {@link Collator}는 스레드 세이프가 아니므로 스레드 로컬로 둡니다. */
     private static final ThreadLocal<Collator> KOREAN_TEXT_ORDER =
             ThreadLocal.withInitial(() -> Collator.getInstance(Locale.KOREA));
 
@@ -51,28 +44,21 @@ public class TodoService {
     private final GroupRepository groupRepository;
     private final MemberGroupRepository memberGroupRepository;
 
-    public WeeklyTodosPageResponseDTO findByUserIdWeekly(Long userId, LocalDate weekStartDate, int page, int size) {
-        LocalDate normalizedWeekStart = weekStartDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-        LocalDate weekEndDate = normalizedWeekStart.plusDays(6);
+    public WeeklyTodosPageResponseDTO findByUserIdInRange(Long userId, LocalDate startDate, int dayCount) {
+        LocalDate endDate = startDate.plusDays(dayCount - 1L);
 
-        Page<Todo> todosPage = todoRepository.findByOwnerIdAndDueDateBetweenWithRelations(
-                userId,
-                normalizedWeekStart,
-                weekEndDate,
-                PageRequest.of(page, size)
-        );
+        List<TodoResponseDTO> todos = todoRepository
+                .findByOwnerIdAndDueDateBetweenWithRelations(userId, startDate, endDate)
+                .stream()
+                .map(TodoResponseDTO::from)
+                .toList();
 
         return new WeeklyTodosPageResponseDTO(
-                normalizedWeekStart,
-                weekEndDate,
-                todosPage.getNumber(),
-                todosPage.getSize(),
-                todosPage.getTotalElements(),
-                todosPage.getTotalPages(),
-                todosPage.hasNext(),
-                todosPage.getContent().stream()
-                        .map(TodoResponseDTO::from)
-                        .toList()
+                startDate,
+                endDate,
+                dayCount,
+                todos.size(),
+                todos
         );
     }
 

--- a/backend/grit/src/main/java/grit/global/config/TimeConfig.java
+++ b/backend/grit/src/main/java/grit/global/config/TimeConfig.java
@@ -1,0 +1,18 @@
+package grit.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+@Configuration
+public class TimeConfig {
+
+    public static final ZoneId SERVICE_ZONE = ZoneId.of("Asia/Seoul");
+
+    @Bean
+    public Clock clock() {
+        return Clock.system(SERVICE_ZONE);
+    }
+}


### PR DESCRIPTION
# 변경점 👍
- 조회 파라미터: `weekStartDate`(주 7일) → `startDate` + `dayCount`(1~7일)
- 페이지네이션(`page`, `size`) 제거, 구간 내 투두 전체 반환
- 응답: `weekStartDate` / `weekEndDate` / 페이지 필드 → `startDate` / `endDate` / `dayCount` / `totalCount` / `todos`