### PR TITLE
feat: 투두 반응형 레이아웃

### DIFF
--- a/frontend/src/apis/constants/queryKeys.ts
+++ b/frontend/src/apis/constants/queryKeys.ts
@@ -17,12 +17,11 @@ export const QUERY_KEYS = {
       ["todos", "achievement", "user", userId ?? "guest"] as const,
     achievementByUser: (userId: number) =>
       ["todos", "achievement", "user", userId] as const,
-    byUserWeek: (
+    byUserRange: (
       userId: number,
-      weekStartDate: string,
-      page: number,
-      size: number,
-    ) => ["todos", "user", userId, weekStartDate, page, size] as const,
+      startDate: string,
+      dayCount: number,
+    ) => ["todos", "user", userId, startDate, dayCount] as const,
   },
   todoCategories: {
     all: ["todoCategories"] as const,

--- a/frontend/src/apis/domains/todo/type.ts
+++ b/frontend/src/apis/domains/todo/type.ts
@@ -50,19 +50,17 @@ export interface TodoApiItem {
 }
 
 export interface TodoListByUserParams {
-  weekStartDate?: string;
-  page?: number;
-  size?: number;
+  /** yyyy-MM-dd, 미입력 시 서버가 이번 주 월요일부터 7일 */
+  startDate?: string;
+  /** 1~7, 미입력 시 서버 기본값 */
+  dayCount?: number;
 }
 
 export interface TodoListByUserResponse {
-  weekStartDate: string;
-  weekEndDate: string;
-  page: number;
-  size: number;
-  totalElements: number;
-  totalPages: number;
-  hasNext: boolean;
+  startDate: string;
+  endDate: string;
+  dayCount: number;
+  totalCount: number;
   todos: TodoApiItem[];
 }
 

--- a/frontend/src/hooks/todo/useTodo.ts
+++ b/frontend/src/hooks/todo/useTodo.ts
@@ -7,12 +7,13 @@ import {
 } from "react";
 import { QUERY_KEYS } from "@/apis/constants/queryKeys";
 import { useToast } from "@/hooks/useToast";
+import type { TodoListFetchParams } from "@/pages/Todo/components/todoWeekLayout";
 import type { Category } from "@/pages/Todo/components/types";
 import { buildUpdateTodoBody } from "./mappers";
 import { useTodoData } from "./useTodoData";
 import { useTodoMutations } from "./useTodoMutations";
 
-export function useTodo(weekStartDate: string) {
+export function useTodo(listParams: TodoListFetchParams) {
   const {
     userId,
     queryClient,
@@ -25,7 +26,7 @@ export function useTodo(weekStartDate: string) {
     setCategories,
     patchTodos,
     setGuestCategories,
-  } = useTodoData({ weekStartDate });
+  } = useTodoData({ listParams });
 
   const { toast, clearToast, notify } = useToast();
 

--- a/frontend/src/hooks/todo/useTodoData.ts
+++ b/frontend/src/hooks/todo/useTodoData.ts
@@ -9,6 +9,7 @@ import { QUERY_KEYS } from "@/apis/constants/queryKeys";
 import { todoApi } from "@/apis/domains/todo/api";
 import { userApi } from "@/apis/domains/user/api";
 import { getAccessToken } from "@/utils/tokenStorage";
+import type { TodoListFetchParams } from "@/pages/Todo/components/todoWeekLayout";
 import {
   DEFAULT_CATEGORIES,
   type Category,
@@ -17,16 +18,11 @@ import {
 import { mapTodoApiToItem, mapTodoCategoryApiToCategory } from "./mappers";
 
 type UseTodoDataOptions = {
-  weekStartDate: string;
-  page?: number;
-  size?: number;
+  listParams: TodoListFetchParams;
 };
 
-export function useTodoData({
-  weekStartDate,
-  page = 0,
-  size = 20,
-}: UseTodoDataOptions) {
+export function useTodoData({ listParams }: UseTodoDataOptions) {
+  const { startDate, dayCount } = listParams;
   const queryClient = useQueryClient();
   const accessToken = getAccessToken();
   const { data: member } = useQuery({
@@ -36,21 +32,19 @@ export function useTodoData({
   });
   const userId = member?.id ?? null;
 
+  const listQueryKey =
+    userId != null
+      ? QUERY_KEYS.todos.byUserRange(userId, startDate, dayCount)
+      : (["todos", "guest"] as const);
+
   const {
     data: serverTodos = [],
     isLoading: isTodosLoading,
     isError: isTodosError,
   } = useQuery({
-    queryKey:
-      userId != null
-        ? QUERY_KEYS.todos.byUserWeek(userId, weekStartDate, page, size)
-        : (["todos", "guest"] as const),
+    queryKey: listQueryKey,
     queryFn: async () => {
-      const response = await todoApi.getList({
-        weekStartDate,
-        page,
-        size,
-      });
+      const response = await todoApi.getList({ startDate, dayCount });
       return response.todos.map(mapTodoApiToItem);
     },
     enabled: userId != null,
@@ -105,12 +99,11 @@ export function useTodoData({
         setGuestTodos((prev) => updater(prev));
         return;
       }
-      queryClient.setQueryData<TodoItem[]>(
-        QUERY_KEYS.todos.byUserWeek(userId, weekStartDate, page, size),
-        (prev) => updater(prev ?? []),
+      queryClient.setQueryData<TodoItem[]>(listQueryKey, (prev) =>
+        updater(prev ?? []),
       );
     },
-    [userId, weekStartDate, page, size, queryClient],
+    [userId, listQueryKey, queryClient],
   );
 
   return {

--- a/frontend/src/pages/Todo/components/DayTodoScrollList.tsx
+++ b/frontend/src/pages/Todo/components/DayTodoScrollList.tsx
@@ -1,0 +1,96 @@
+import { ChevronDown } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+const SCROLL_EDGE = 6;
+
+function useScrollMoreBelow(ref: React.RefObject<HTMLUListElement | null>) {
+  const [showMore, setShowMore] = useState(false);
+
+  const update = useCallback(() => {
+    const el = ref.current;
+    if (!el) {
+      setShowMore(false);
+      return;
+    }
+    const overflow = el.scrollHeight - el.clientHeight;
+    const hasMore = overflow > SCROLL_EDGE;
+    const atBottom =
+      el.scrollTop + el.clientHeight >= el.scrollHeight - SCROLL_EDGE;
+    setShowMore(hasMore && !atBottom);
+  }, [ref]);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    update();
+    el.addEventListener("scroll", update, { passive: true });
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+
+    return () => {
+      el.removeEventListener("scroll", update);
+      ro.disconnect();
+    };
+  }, [update]);
+
+  return showMore;
+}
+
+type DayTodoScrollListProps = {
+  children: ReactNode;
+};
+
+export default function DayTodoScrollList({ children }: DayTodoScrollListProps) {
+  const listRef = useRef<HTMLUListElement>(null);
+  const showMore = useScrollMoreBelow(listRef);
+
+  const scrollDown = () => {
+    const el = listRef.current;
+    if (!el) return;
+    el.scrollBy({ top: el.clientHeight * 0.72, behavior: "smooth" });
+  };
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      <ul
+        ref={listRef}
+        className="relative z-[1] flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overscroll-contain list-none px-2 pt-2 pb-4 [scrollbar-gutter:stable]"
+      >
+        {children}
+      </ul>
+
+      <div
+        className={`absolute inset-x-0 bottom-0 z-[2] flex justify-center transition-opacity duration-300 ease-out ${
+          showMore ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+        aria-hidden={!showMore}
+      >
+        <button
+          type="button"
+          tabIndex={showMore ? 0 : -1}
+          onClick={scrollDown}
+          className="group/scroll-more relative flex w-full flex-col items-center pb-2 pt-8"
+          aria-label="아래로 스크롤하여 더 보기"
+        >
+          <span
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-[#2A2F38] from-25% via-[#2A2F38]/70 to-transparent"
+            aria-hidden
+          />
+          <ChevronDown
+            className="relative text-white/40 transition-colors group-hover/scroll-more:text-white/65"
+            size={18}
+            strokeWidth={2.25}
+            aria-hidden
+          />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Todo/components/TodoWeekGrid.tsx
+++ b/frontend/src/pages/Todo/components/TodoWeekGrid.tsx
@@ -1,12 +1,18 @@
 import { ChevronLeft, ChevronRight, LoaderCircle, Plus, XCircle } from "lucide-react";
+import DayTodoScrollList from "./DayTodoScrollList";
 import TodoComposeBlock from "./TodoComposeBlock";
 import TodoRow from "./TodoRow";
 import type { Category, TodoItem, TodoQuickAddConfig } from "./types";
+import {
+  gridColsClassForCount,
+  type TodoWeekColumnCount,
+} from "./todoWeekLayout";
 import {
   DND_TODO_MIME,
   WEEKDAY_KO,
   isSameCalendarDay,
   toDateKey,
+  weekdayIndexMondayFirst,
   weeklyAddButtonClass,
   weeklyDayHeaderClass,
   weeklyListPanelClass,
@@ -28,7 +34,7 @@ export function TodoWeekHeader({
   fetchStatus = "idle",
 }: TodoWeekHeaderProps) {
   return (
-    <div className="sticky top-[65px] z-30 shrink-0 border-b border-white/10 bg-gray-darkest/95 py-2 pb-3 backdrop-blur-md supports-[backdrop-filter]:bg-gray-darkest/90">
+    <div className="z-30 shrink-0 border-b border-white/10 bg-gray-darkest py-2 pb-3">
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <h2 className="font-semibold text-white text-h3">{monthHeading}</h2>
@@ -74,6 +80,7 @@ export function TodoWeekHeader({
 
 type TodoWeekGridProps = {
   weekDays: Date[];
+  columnCount: TodoWeekColumnCount;
   today: Date;
   todos: TodoItem[];
   categories: Category[];
@@ -127,6 +134,7 @@ function compareTodoDisplayOrder(a: TodoItem, b: TodoItem): number {
 
 export default function TodoWeekGrid({
   weekDays,
+  columnCount,
   today,
   todos,
   categories,
@@ -145,10 +153,13 @@ export default function TodoWeekGrid({
   onCancelEdit,
 }: TodoWeekGridProps) {
   return (
-    <div className="w-full min-w-0 pt-4 pb-10">
-      <div className="grid grid-cols-7 gap-2">
-        {weekDays.map((day, i) => {
+    <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col pt-3">
+      <div
+        className={`grid min-h-0 flex-1 grid-rows-1 gap-2 ${gridColsClassForCount(columnCount)}`}
+      >
+        {weekDays.map((day) => {
           const key = toDateKey(day);
+          const weekdayIndex = weekdayIndexMondayFirst(day);
           const composePicker = {
             categories,
             setCategories: quickAdd.setCategories,
@@ -167,8 +178,8 @@ export default function TodoWeekGrid({
             .filter((t) => t.dueDate === key)
             .sort(compareTodoDisplayOrder);
           const isToday = isSameCalendarDay(day, today);
-          const isSaturday = i === 5;
-          const isSunday = i === 6;
+          const isSaturday = weekdayIndex === 5;
+          const isSunday = weekdayIndex === 6;
 
           const listPanelClass = weeklyListPanelClass(
             isToday,
@@ -189,13 +200,13 @@ export default function TodoWeekGrid({
           return (
             <div
               key={key}
-              className="relative flex h-full min-h-[min(560px,62vh)] w-full min-w-0 flex-col gap-2"
+              className="relative flex h-full min-h-0 w-full min-w-0 flex-col gap-2"
             >
               <div className={`group/day-head ${dayHeaderClass}`}>
                 <div className="flex items-center justify-between gap-2 px-4 py-3.5">
                   <div
                     className="flex min-w-0 flex-1 items-baseline gap-2 text-left"
-                    aria-label={`${WEEKDAY_KO[i]}요일 ${day.getDate()}일`}
+                    aria-label={`${WEEKDAY_KO[weekdayIndex]}요일 ${day.getDate()}일`}
                   >
                     <span
                       className={`shrink-0 text-h3 font-bold tabular-nums leading-none ${
@@ -221,7 +232,7 @@ export default function TodoWeekGrid({
                               : "text-white/55"
                       }`}
                     >
-                      {WEEKDAY_KO[i]}
+                      {WEEKDAY_KO[weekdayIndex]}
                     </span>
                   </div>
                   {onAddTodoForDate ? (
@@ -266,7 +277,7 @@ export default function TodoWeekGrid({
                   setDragOverDateKey(null);
                 }}
               >
-                <ul className="relative z-[1] flex flex-1 flex-col gap-3 list-none px-2 pt-2 pb-6">
+                <DayTodoScrollList>
                 {quickAdd.pendingDueDate === key ? (
                   <li className="shrink-0">
                     <TodoComposeBlock
@@ -305,7 +316,7 @@ export default function TodoWeekGrid({
                     />
                   ),
                 )}
-                </ul>
+                </DayTodoScrollList>
               </div>
             </div>
           );

--- a/frontend/src/pages/Todo/components/todoWeekLayout.ts
+++ b/frontend/src/pages/Todo/components/todoWeekLayout.ts
@@ -1,0 +1,69 @@
+import { addDays, toDateKey } from "./weeklyTodo";
+
+/**
+ * 투두 주간 그리드 7일 → 5일 → 3일 전환 기준 (콘텐츠 영역 너비, px).
+ * 이 객체 값만 수정하면 됩니다.
+ */
+export const TODO_WEEK_LAYOUT_BREAKPOINTS = {
+  /** 이 너비 미만이면 5열 */
+  fiveColumnsMaxWidth: 1200,
+  /** 이 너비 미만이면 3열 */
+  threeColumnsMaxWidth: 900,
+} as const;
+
+export type TodoWeekColumnCount = 7 | 5 | 3;
+
+export function columnCountForContainerWidth(width: number): TodoWeekColumnCount {
+  if (width < TODO_WEEK_LAYOUT_BREAKPOINTS.threeColumnsMaxWidth) return 3;
+  if (width < TODO_WEEK_LAYOUT_BREAKPOINTS.fiveColumnsMaxWidth) return 5;
+  return 7;
+}
+
+/** 3·5열일 때 오늘을 첫 열로, columnCount일 만큼 표시 (다음 주로 넘어갈 수 있음) */
+export function getVisibleWeekDays(
+  weekDays: Date[],
+  today: Date,
+  columnCount: TodoWeekColumnCount,
+): Date[] {
+  if (columnCount === 7 || weekDays.length === 0) return weekDays;
+
+  const weekStart = weekDays[0]!;
+  const weekEnd = weekDays[weekDays.length - 1]!;
+  const startMs = weekStart.getTime();
+  const endMs = weekEnd.getTime();
+  const todayMs = today.getTime();
+
+  const start =
+    todayMs >= startMs && todayMs <= endMs ? today : weekStart;
+
+  return Array.from({ length: columnCount }, (_, i) => addDays(start, i));
+}
+
+export type TodoListFetchParams = {
+  startDate: string;
+  dayCount: number;
+};
+
+/** GET /api/members/me/todos 쿼리 — 화면에 보이는 열과 동일한 범위 */
+export function getTodoListFetchParams(
+  weekDays: Date[],
+  today: Date,
+  columnCount: TodoWeekColumnCount,
+): TodoListFetchParams {
+  const visible = getVisibleWeekDays(weekDays, today, columnCount);
+  return {
+    startDate: toDateKey(visible[0]!),
+    dayCount: visible.length,
+  };
+}
+
+export function gridColsClassForCount(columnCount: TodoWeekColumnCount): string {
+  switch (columnCount) {
+    case 3:
+      return "grid-cols-3";
+    case 5:
+      return "grid-cols-5";
+    default:
+      return "grid-cols-7";
+  }
+}

--- a/frontend/src/pages/Todo/components/weeklyTodo.ts
+++ b/frontend/src/pages/Todo/components/weeklyTodo.ts
@@ -2,6 +2,10 @@ export const DND_TODO_MIME = "application/x-grit-todo-id";
 
 export const WEEKDAY_KO = ["월", "화", "수", "목", "금", "토", "일"] as const;
 
+export function weekdayIndexMondayFirst(day: Date): number {
+  return (day.getDay() + 6) % 7;
+}
+
 const LIST_PANEL = {
   solid: "overflow-hidden rounded-xl bg-[#2A2F38]",
   layered:

--- a/frontend/src/pages/Todo/hooks/useTodoWeekColumnCount.ts
+++ b/frontend/src/pages/Todo/hooks/useTodoWeekColumnCount.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  columnCountForContainerWidth,
+  type TodoWeekColumnCount,
+} from "@/pages/Todo/components/todoWeekLayout";
+
+export function useTodoWeekColumnCount() {
+  const [columnCount, setColumnCount] = useState<TodoWeekColumnCount>(7);
+  const nodeRef = useRef<HTMLDivElement | null>(null);
+  const observerRef = useRef<ResizeObserver | null>(null);
+
+  const disconnectObserver = () => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+  };
+
+  const measure = useCallback(() => {
+    const el = nodeRef.current;
+    if (!el) return;
+    const width = el.getBoundingClientRect().width;
+    const next = columnCountForContainerWidth(width);
+    setColumnCount((prev) => (prev === next ? prev : next));
+  }, []);
+
+  const layoutRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      disconnectObserver();
+      nodeRef.current = node;
+      if (!node) return;
+
+      measure();
+      const ro = new ResizeObserver(measure);
+      ro.observe(node);
+      observerRef.current = ro;
+    },
+    [measure],
+  );
+
+  useEffect(() => {
+    window.addEventListener("resize", measure);
+    return () => {
+      window.removeEventListener("resize", measure);
+      disconnectObserver();
+    };
+  }, [measure]);
+
+  return { columnCount, layoutRef };
+}

--- a/frontend/src/pages/Todo/index.tsx
+++ b/frontend/src/pages/Todo/index.tsx
@@ -8,11 +8,15 @@ import TodoWeekGrid, {
 } from "@/pages/Todo/components/TodoWeekGrid";
 import type { TodoItem } from "@/pages/Todo/components/types";
 import {
+  getTodoListFetchParams,
+  getVisibleWeekDays,
+} from "@/pages/Todo/components/todoWeekLayout";
+import {
   addDays,
   formatMonthHeading,
   startOfWeekMonday,
-  toDateKey,
 } from "@/pages/Todo/components/weeklyTodo";
+import { useTodoWeekColumnCount } from "@/pages/Todo/hooks/useTodoWeekColumnCount";
 
 const TodoPage = () => {
   const [anchor, setAnchor] = useState(() => new Date());
@@ -21,25 +25,32 @@ const TodoPage = () => {
   const onDragEndClear = () => setDragOverDateKey(null);
 
   const weekStart = useMemo(() => startOfWeekMonday(anchor), [anchor]);
-  const weekStartDate = useMemo(() => toDateKey(weekStart), [weekStart]);
-  const b = useTodo(weekStartDate);
   const monthHeading = useMemo(() => formatMonthHeading(weekStart), [weekStart]);
   const weekDays = useMemo(
     () => Array.from({ length: 7 }, (_, i) => addDays(weekStart, i)),
     [weekStart],
   );
+  const today = useMemo(() => {
+    const t = new Date();
+    t.setHours(0, 0, 0, 0);
+    return t;
+  }, []);
+  const { columnCount, layoutRef } = useTodoWeekColumnCount();
+  const visibleWeekDays = useMemo(
+    () => getVisibleWeekDays(weekDays, today, columnCount),
+    [weekDays, today, columnCount],
+  );
+  const listFetchParams = useMemo(
+    () => getTodoListFetchParams(weekDays, today, columnCount),
+    [weekDays, today, columnCount],
+  );
+  const b = useTodo(listFetchParams);
   const todoFetchStatus = useMemo<"idle" | "loading" | "error">(() => {
     if (b.userId == null) return "idle";
     if (b.isTodosError || b.isCategoriesError) return "error";
     if (b.isTodosLoading || b.isCategoriesLoading) return "loading";
     return "idle";
   }, [b.userId, b.isTodosError, b.isCategoriesError, b.isTodosLoading, b.isCategoriesLoading]);
-
-  const today = useMemo(() => {
-    const t = new Date();
-    t.setHours(0, 0, 0, 0);
-    return t;
-  }, []);
 
   const categoryLabelForTodo = (todo: TodoItem) => {
     if (todo.categoryName) return todo.categoryName;
@@ -77,18 +88,21 @@ const TodoPage = () => {
 
   return (
     <SmallViewportNotice>
-      <div className="relative flex min-h-screen w-full flex-col overflow-x-hidden bg-gray-darkest pt-[65px]">
+      <div className="relative flex h-screen w-full flex-col overflow-hidden bg-gray-darkest pt-[65px]">
         <Header variant="dark" alwaysVisible />
-        <div className="flex flex-col w-full min-w-0 select-none">
+        <div className="flex min-h-0 flex-1 flex-col w-full min-w-0 select-none overflow-hidden">
           <Toast toast={b.toast} onClear={b.clearToast} />
-          <div className="flex flex-col gap-2 px-8 pt-4 pb-20">
+          <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden px-20 py-20 md:py-14">
             {b.userId != null && b.isCategoriesError ? (
               <p className="text-sm shrink-0 text-red-300/95">
                 카테고리 목록을 불러오지 못했습니다.
               </p>
             ) : null}
-            <div className="flex w-full min-w-0 justify-center">
-              <div className="relative my-20 flex w-full min-w-0 max-w-[1440px] flex-col px-2 md:px-4">
+            <div
+              ref={layoutRef}
+              className="flex min-h-0 flex-1 w-full min-w-0 justify-center overflow-hidden"
+            >
+              <div className="relative flex min-h-0 w-full min-w-0 max-w-[1440px] flex-1 flex-col px-2 md:px-4">
                 <TodoWeekHeader
                   monthHeading={monthHeading}
                   onPrevWeek={prevWeek}
@@ -98,7 +112,8 @@ const TodoPage = () => {
                 />
 
                 <TodoWeekGrid
-                  weekDays={weekDays}
+                  weekDays={visibleWeekDays}
+                  columnCount={columnCount}
                   today={today}
                   todos={b.todos}
                   categories={b.categories}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -34,4 +34,5 @@ export default {
     },
   },
   plugins: [],
+  safelist: ['grid-cols-3', 'grid-cols-5', 'grid-cols-7'],
 };


### PR DESCRIPTION
# 변경점 👍
- 페이지 스크롤 제거, 요일 칸 내부 스크롤 및 하단 더보기 힌트 추가
- 뷰포트 너비에 따라 7/5/3열 전환, 5·3열은 오늘을 첫 열로 표시
- 투두 목록 API를 startDate/dayCount 기준으로 변경하고 화면 범위와 동기화
