### PR TITLE
feat: 유저 구분용 public member 키 추가(UUID)

### DIFF
--- a/backend/grit/src/main/java/grit/domain/group/livekit/service/LiveKitService.java
+++ b/backend/grit/src/main/java/grit/domain/group/livekit/service/LiveKitService.java
@@ -47,7 +47,7 @@ public class LiveKitService {
         checkPermission(member, group);
 
         AccessToken token = new AccessToken(apiKey, apiSecret);
-        token.setIdentity(member.getId().toString());
+        token.setIdentity(member.getPublicId().toString());
         token.setName(member.getNickname());
         token.addGrants(
                 new RoomJoin(true),
@@ -64,9 +64,10 @@ public class LiveKitService {
         checkPermission(member, group);
         sendData(roomName(group.getCode()),
                 Map.of(
+                        "type", "reaction",
                         "emoji", emoji.name(),
                         "emojiChar", emoji.getEmoji(),
-                        "senderUserId", member.getId()
+                        "senderIdentity", member.getPublicId().toString()
                 ), Kind.RELIABLE);
     }
 

--- a/backend/grit/src/main/java/grit/domain/member/dto/MemberResponseDto.java
+++ b/backend/grit/src/main/java/grit/domain/member/dto/MemberResponseDto.java
@@ -11,8 +11,8 @@ import java.util.UUID;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record MemberResponseDto(
 
-        @Schema(description = "사용자 고유 ID (PK)", example = "1")
-        Long id,
+        @Schema(description = "외부 노출용 사용자 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
+        UUID publicId,
 
         @Schema(description = "닉네임", example = "그릿유저")
         String nickname,
@@ -39,7 +39,7 @@ public record MemberResponseDto(
 
     public static MemberResponseDto fromWithResolvedUrl(Member member, String imageUrl) {
         return new MemberResponseDto(
-                    member.getId(),
+                    member.getPublicId(),
                     member.getNickname(),
                     member.getEmail(),
                     member.getIntroduction(),
@@ -54,7 +54,7 @@ public record MemberResponseDto(
     // 친구 목록용 변환 (이메일 제외)
     public static MemberResponseDto fromForFriend(Member member, String imageUrl) {
         return new MemberResponseDto(
-                    member.getId(),
+                    member.getPublicId(),
                     member.getNickname(),
                     null,          // email 비공개
                     member.getIntroduction(),

--- a/backend/grit/src/main/java/grit/domain/member/entity/Member.java
+++ b/backend/grit/src/main/java/grit/domain/member/entity/Member.java
@@ -19,13 +19,22 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "members")
+@Table(
+        name = "members",
+        indexes = {
+                @Index(name = "ux_members_public_id", columnList = "public_id", unique = true)
+        }
+)
 @ToString(callSuper = true, exclude = { "memberGroups", "friends" }) // lombok 무한루프 방지용
 public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Builder.Default
+    @Column(nullable = false, updatable = false)
+    private UUID publicId = UUID.randomUUID();
 
     @Setter
     @Column(unique = true, length = 10) // 소셜 로그인 닉네임 받기 전일 때 위해서 null 허용

--- a/backend/grit/src/main/resources/static/livekit.html
+++ b/backend/grit/src/main/resources/static/livekit.html
@@ -734,10 +734,10 @@
                 const text = new TextDecoder().decode(payload);
                 const data = JSON.parse(text);
 
-                if (!data.emojiChar || !data.senderUserId) return;
+                if (data.type !== 'reaction') return;
+                if (!data.emojiChar || !data.senderIdentity) return;
 
-                const senderId = String(data.senderUserId);
-                showReactionOnTile(senderId, data.emojiChar);
+                showReactionOnTile(data.senderIdentity, data.emojiChar);
             } catch (err) {
                 console.error('리액션 수신 파싱 오류:', err);
             }


### PR DESCRIPTION
# 변경점 👍
 - 유저 구분용 public member 키 추가(UUID) - 화상회의 진행 중 닉네임 변경 시에도 문제가 발생하지 않음
