### PR TITLE
feat: LiveKit 데이터 전송 추적 추가

### DIFF
--- a/backend/grit/src/main/java/grit/domain/group/livekit/service/LiveKitService.java
+++ b/backend/grit/src/main/java/grit/domain/group/livekit/service/LiveKitService.java
@@ -13,7 +13,10 @@ import io.livekit.server.CanSubscribe;
 import io.livekit.server.RoomJoin;
 import io.livekit.server.RoomName;
 import io.livekit.server.RoomServiceClient;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
 import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -40,6 +43,7 @@ public class LiveKitService {
     private final GroupService groupService;
     private final ObjectMapper objectMapper;
     private final Clock clock;
+    private final ObservationRegistry observationRegistry;
     private RoomServiceClient client;
 
     @PostConstruct
@@ -68,6 +72,7 @@ public class LiveKitService {
         Group group = groupService.findGroupByCode(groupCode);
         checkPermission(member, group);
         sendData(roomName(group.getCode()),
+                "reaction",
                 Map.of(
                         "type", "reaction",
                         "emoji", emoji.name(),
@@ -91,6 +96,7 @@ public class LiveKitService {
         timer.put("totalRounds", pomodoro.getTotalRounds());
 
         sendData(roomName(group.getCode()),
+                "pomodoro.sync",
                 Map.of(
                         "type", "pomodoro.sync",
                         "timer", timer,
@@ -98,12 +104,24 @@ public class LiveKitService {
                 ), Kind.RELIABLE);
     }
 
-    private void sendData(String roomName, Object payload, Kind kind) {
-        try {
+    private void sendData(String roomName, String messageType, Object payload, Kind kind) {
+        Observation observation = Observation.createNotStarted("livekit.send_data", observationRegistry)
+                .contextualName("LiveKit send data")
+                .lowCardinalityKeyValue("livekit.message_type", messageType)
+                .lowCardinalityKeyValue("livekit.kind", kind.name())
+                .highCardinalityKeyValue("livekit.room", roomName)
+                .start();
+
+        try (Observation.Scope ignored = observation.openScope()) {
             String json = objectMapper.writeValueAsString(payload);
-            client.sendData(roomName, json.getBytes(), kind).execute();
+            byte[] payloadBytes = json.getBytes(StandardCharsets.UTF_8);
+            observation.highCardinalityKeyValue("livekit.payload.bytes", String.valueOf(payloadBytes.length));
+            client.sendData(roomName, payloadBytes, kind).execute();
         } catch (Exception e) {
+            observation.error(e);
             throw new RuntimeException("Failed to send data to LiveKit", e);
+        } finally {
+            observation.stop();
         }
     }
 

--- a/backend/grit/src/main/java/grit/domain/group/livekit/service/LiveKitService.java
+++ b/backend/grit/src/main/java/grit/domain/group/livekit/service/LiveKitService.java
@@ -25,6 +25,7 @@ import livekit.LivekitModels.DataPacket.Kind;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import retrofit2.Response;
 import tools.jackson.databind.ObjectMapper;
 
 @Service
@@ -116,7 +117,13 @@ public class LiveKitService {
             String json = objectMapper.writeValueAsString(payload);
             byte[] payloadBytes = json.getBytes(StandardCharsets.UTF_8);
             observation.highCardinalityKeyValue("livekit.payload.bytes", String.valueOf(payloadBytes.length));
-            client.sendData(roomName, payloadBytes, kind).execute();
+            Response<Void> response = client.sendData(roomName, payloadBytes, kind).execute();
+            if (!response.isSuccessful()) {
+                throw new RuntimeException("LiveKit send data failed. status="
+                        + response.code()
+                        + ", message="
+                        + response.message());
+            }
         } catch (Exception e) {
             observation.error(e);
             throw new RuntimeException("Failed to send data to LiveKit", e);


### PR DESCRIPTION
# 변경점 👍
뽀모도로 API 응답 시간이 70ms~10000ms+ 로 불안정한 원인 파악을 위해 LiveKit 통신 구간에 Observation 관련 코드를 추가합니다.
- LiveKit 데이터 전송 구간에 `livekit.send_data` Observation span 추가
- `reaction`, `pomodoro.sync` 메시지 타입을 tag로 구분 가능하도록 처리
- payload 크기, room, kind 정보도 trace tag로 기록
