### PR TITLE
feat: LiveKit 뽀모도로 실시간 동기화 및 Room 페이지 구조 분리

### DIFF
--- a/frontend/src/apis/domains/livekit/pomodoroSync.ts
+++ b/frontend/src/apis/domains/livekit/pomodoroSync.ts
@@ -1,0 +1,35 @@
+import type { PomodoroStatusResponse } from "@/apis/domains/pomodoro/type";
+import type { LiveKitPomodoroSyncMessage } from "@/apis/domains/livekit/type";
+
+export const isLiveKitPomodoroSyncMessage = (
+  value: unknown,
+): value is LiveKitPomodoroSyncMessage => {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<LiveKitPomodoroSyncMessage>;
+  const timer = candidate.timer;
+
+  return (
+    candidate.type === "pomodoro.sync" &&
+    typeof candidate.senderNickname === "string" &&
+    !!timer &&
+    typeof timer === "object" &&
+    typeof (timer as PomodoroStatusResponse).status === "string" &&
+    typeof (timer as PomodoroStatusResponse).serverNow === "string"
+  );
+};
+
+export const toPomodoroStatusResponse = (
+  timer: LiveKitPomodoroSyncMessage["timer"],
+): PomodoroStatusResponse => ({
+  status: timer.status,
+  phase: timer.phase,
+  serverNow: timer.serverNow,
+  focusEndsAt: timer.focusEndsAt,
+  breakEndsAt: timer.breakEndsAt,
+  pausedAt: timer.pausedAt,
+  focusMinutes: timer.focusMinutes,
+  breakMinutes: timer.breakMinutes,
+  currentRound: timer.currentRound,
+  totalRounds: timer.totalRounds,
+});

--- a/frontend/src/apis/domains/livekit/reactionSync.ts
+++ b/frontend/src/apis/domains/livekit/reactionSync.ts
@@ -1,0 +1,14 @@
+import type { LiveKitReactionMessage } from "@/apis/domains/livekit/type";
+
+export const isLiveKitReactionMessage = (
+  value: unknown,
+): value is LiveKitReactionMessage => {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<LiveKitReactionMessage>;
+  return (
+    typeof candidate.emoji === "string" &&
+    typeof candidate.emojiChar === "string" &&
+    typeof candidate.senderNickname === "string"
+  );
+};

--- a/frontend/src/apis/domains/livekit/type.ts
+++ b/frontend/src/apis/domains/livekit/type.ts
@@ -1,3 +1,5 @@
+import type { PomodoroStatusResponse } from "@/apis/domains/pomodoro/type";
+
 export interface TokenResponse {
   token: string;
 }
@@ -7,7 +9,6 @@ export interface Reaction {
   emoji: string;
 }
 
-/** POST body: 필드명 emoji, 값은 ReactionEmoji enum 문자열 (예: THUMBS_UP) */
 export interface SendReactionRequest {
   emoji: string;
 }
@@ -16,4 +17,10 @@ export interface LiveKitReactionMessage {
   emoji: string;
   emojiChar: string;
   senderNickname: string;
+}
+
+export interface LiveKitPomodoroSyncMessage {
+  type: "pomodoro.sync";
+  senderNickname: string;
+  timer: PomodoroStatusResponse;
 }

--- a/frontend/src/pages/Room/components/RoomPomodoro.tsx
+++ b/frontend/src/pages/Room/components/RoomPomodoro.tsx
@@ -1,0 +1,43 @@
+import Pomodoro from "@/pages/Room/components/Cam/Pomodoro";
+import type { PomodoroStatusResponse } from "@/apis/domains/pomodoro/type";
+
+const DEFAULT_FOCUS_MINUTES = 45;
+const DEFAULT_BREAK_MINUTES = 15;
+const DEFAULT_TOTAL_ROUNDS = 1;
+
+type RoomPomodoroProps = {
+  pomodoroStatus: PomodoroStatusResponse | undefined;
+};
+
+export default function RoomPomodoro({ pomodoroStatus }: RoomPomodoroProps) {
+  const isRunning =
+    pomodoroStatus?.status === "RUNNING" ||
+    pomodoroStatus?.status === "BREAK" ||
+    pomodoroStatus?.status === "PAUSED";
+
+  return (
+    <Pomodoro
+      studyMinutes={
+        isRunning
+          ? (pomodoroStatus?.focusMinutes ?? DEFAULT_FOCUS_MINUTES)
+          : DEFAULT_FOCUS_MINUTES
+      }
+      breakMinutes={
+        isRunning
+          ? (pomodoroStatus?.breakMinutes ?? DEFAULT_BREAK_MINUTES)
+          : DEFAULT_BREAK_MINUTES
+      }
+      repeat={
+        isRunning
+          ? (pomodoroStatus?.totalRounds ?? DEFAULT_TOTAL_ROUNDS)
+          : DEFAULT_TOTAL_ROUNDS
+      }
+      autoStart={isRunning && pomodoroStatus?.status !== "PAUSED"}
+      serverNow={isRunning ? pomodoroStatus?.serverNow : undefined}
+      phase={isRunning ? pomodoroStatus?.phase : undefined}
+      focusEndsAt={isRunning ? pomodoroStatus?.focusEndsAt : undefined}
+      breakEndsAt={isRunning ? pomodoroStatus?.breakEndsAt : undefined}
+      currentRound={isRunning ? (pomodoroStatus?.currentRound ?? 1) : 1}
+    />
+  );
+}

--- a/frontend/src/pages/Room/hooks/index.ts
+++ b/frontend/src/pages/Room/hooks/index.ts
@@ -1,0 +1,5 @@
+export { useRoomLiveKit } from "./useRoomLiveKit";
+export { useRoomLiveKitData } from "./useRoomLiveKitData";
+export { useRoomParticipants } from "./useRoomParticipants";
+export { useRoomPomodoro } from "./useRoomPomodoro";
+export { useRoomReactions } from "./useRoomReactions";

--- a/frontend/src/pages/Room/hooks/useRoomLiveKit.ts
+++ b/frontend/src/pages/Room/hooks/useRoomLiveKit.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getLiveKitToken } from "@/apis/domains/livekit/api";
+import { LIVEKIT_URL } from "@/apis/constants/endpoints";
+import { useLiveKit } from "@/hooks/useLiveKit";
+import { PATHS } from "@/routes/path";
+
+export function useRoomLiveKit(
+  groupCode: string | undefined,
+  onDataReceived: (payload: Uint8Array) => void,
+) {
+  const navigate = useNavigate();
+  const [token, setToken] = useState<string | null>(null);
+
+  const {
+    participants: remoteParticipants,
+    room,
+    error,
+    isMicrophoneEnabled,
+    isCameraEnabled,
+    isMediaTogglePending,
+    toggleMicrophone,
+    toggleCamera,
+  } = useLiveKit({
+    serverUrl: token ? LIVEKIT_URL : "",
+    token: token || "",
+    onDataReceived,
+  });
+
+  useEffect(() => {
+    if (!groupCode) return;
+
+    const fetchToken = async () => {
+      try {
+        const newToken = await getLiveKitToken(groupCode);
+        setToken(newToken);
+      } catch (err) {
+        console.error("LiveKit 토큰 발급 실패", err);
+      }
+    };
+
+    fetchToken();
+  }, [groupCode]);
+
+  useEffect(() => {
+    if (error) {
+      console.error("livekit 에러", error);
+    }
+  }, [error]);
+
+  const handleLeaveRoom = useCallback(() => {
+    room?.disconnect();
+    navigate(PATHS.HOME);
+  }, [navigate, room]);
+
+  return {
+    remoteParticipants,
+    isMicrophoneEnabled,
+    isCameraEnabled,
+    isMediaTogglePending,
+    toggleMicrophone,
+    toggleCamera,
+    handleLeaveRoom,
+  };
+}

--- a/frontend/src/pages/Room/hooks/useRoomLiveKitData.ts
+++ b/frontend/src/pages/Room/hooks/useRoomLiveKitData.ts
@@ -1,0 +1,28 @@
+import { useCallback } from "react";
+import { useRoomPomodoro } from "@/pages/Room/hooks/useRoomPomodoro";
+import { useRoomReactions } from "@/pages/Room/hooks/useRoomReactions";
+
+export function useRoomLiveKitData(groupCode: string | undefined) {
+  const pomodoro = useRoomPomodoro(groupCode);
+  const reactions = useRoomReactions(groupCode);
+
+  const handleDataReceived = useCallback(
+    (payload: Uint8Array) => {
+      try {
+        const data = JSON.parse(new TextDecoder().decode(payload));
+
+        if (pomodoro.applyLiveKitSync(data)) return;
+        reactions.applyLiveKitReaction(data);
+      } catch {
+        // 파싱 불가한 메시지는 무시
+      }
+    },
+    [pomodoro.applyLiveKitSync, reactions.applyLiveKitReaction],
+  );
+
+  return {
+    pomodoro,
+    reactions,
+    handleDataReceived,
+  };
+}

--- a/frontend/src/pages/Room/hooks/useRoomParticipants.tsx
+++ b/frontend/src/pages/Room/hooks/useRoomParticipants.tsx
@@ -1,0 +1,80 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import VideoTile from "@/pages/Room/components/Cam/VideoTile";
+import {
+  getParticipantMatchKeys,
+  getProfileImageUrl,
+} from "@/pages/Room/utils/participantUtils";
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
+import { groupApi } from "@/apis/domains/group/api";
+import { userApi } from "@/apis/domains/user/api";
+import type { ParticipantData } from "@/types/livekit";
+
+export function useRoomParticipants(
+  groupCode: string | undefined,
+  remoteParticipants: ParticipantData[],
+) {
+  const { data: groupMembers = [] } = useQuery({
+    queryKey: QUERY_KEYS.groups.members(groupCode ?? ""),
+    queryFn: () => groupApi.getGroupMembers(groupCode!),
+    enabled: !!groupCode,
+  });
+
+  const { data: currentMember } = useQuery({
+    queryKey: QUERY_KEYS.member.me,
+    queryFn: userApi.get,
+  });
+
+  const groupMemberByKey = useMemo(() => {
+    const map = new Map<string, (typeof groupMembers)[number]>();
+
+    groupMembers.forEach((member) => {
+      getParticipantMatchKeys(member).forEach((key) => {
+        map.set(key, member);
+      });
+    });
+
+    return map;
+  }, [groupMembers]);
+
+  const participants = useMemo(
+    () =>
+      remoteParticipants.map((participant) => {
+        const isCurrentParticipant =
+          participant.identity === String(currentMember?.id) ||
+          participant.identity === currentMember?.email ||
+          participant.name === currentMember?.nickname;
+        const matchedGroupMember =
+          groupMemberByKey.get(participant.identity) ??
+          groupMemberByKey.get(participant.name) ??
+          (isCurrentParticipant ? currentMember : undefined);
+        const profileImageUrl =
+          participant.imageUrl ??
+          getProfileImageUrl(matchedGroupMember) ??
+          (isCurrentParticipant ? getProfileImageUrl(currentMember) : null);
+        const hasVideo = participant.isVideoEnabled && participant.videoTrack;
+
+        return {
+          id: participant.identity,
+          name: participant.name,
+          isMuted: participant.isMuted,
+          profileImageUrl,
+          video: hasVideo ? (
+            <VideoTile
+              videoTrack={participant.videoTrack ?? undefined}
+              audioTrack={participant.audioTrack ?? undefined}
+            />
+          ) : undefined,
+          audio: !hasVideo ? (
+            <VideoTile audioTrack={participant.audioTrack ?? undefined} />
+          ) : undefined,
+        };
+      }),
+    [currentMember, groupMemberByKey, remoteParticipants],
+  );
+
+  return {
+    groupMembers,
+    participants,
+  };
+}

--- a/frontend/src/pages/Room/hooks/useRoomPomodoro.ts
+++ b/frontend/src/pages/Room/hooks/useRoomPomodoro.ts
@@ -1,0 +1,80 @@
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  isLiveKitPomodoroSyncMessage,
+  toPomodoroStatusResponse,
+} from "@/apis/domains/livekit/pomodoroSync";
+import type { StartPomodoroRequest } from "@/apis/domains/pomodoro/type";
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
+import { usePomodoroStatus } from "@/hooks/usePomodoroStatus";
+import { useStartPomodoro } from "@/hooks/useStartPomodoro";
+import { usePausePomodoro } from "@/hooks/usePausePomodoro";
+import { useResumePomodoro } from "@/hooks/useResumePomodoro";
+import { useStopPomodoro } from "@/hooks/useStopPomodoro";
+
+export function useRoomPomodoro(groupCode: string | undefined) {
+  const queryClient = useQueryClient();
+
+  const { data: pomodoroStatus } = usePomodoroStatus({
+    groupCode,
+    enabled: !!groupCode,
+  });
+
+  const { mutate: startPomodoro, isPending: isStartingPomodoro } =
+    useStartPomodoro(groupCode);
+  const { mutate: pausePomodoro, isPending: isPausingPomodoro } =
+    usePausePomodoro(groupCode);
+  const { mutate: resumePomodoro, isPending: isResumingPomodoro } =
+    useResumePomodoro(groupCode);
+  const { mutate: stopPomodoro, isPending: isStoppingPomodoro } =
+    useStopPomodoro(groupCode);
+
+  const applyLiveKitSync = useCallback(
+    (data: unknown): boolean => {
+      if (!isLiveKitPomodoroSyncMessage(data) || !groupCode) return false;
+
+      queryClient.setQueryData(
+        QUERY_KEYS.pomodoro.status(groupCode),
+        toPomodoroStatusResponse(data.timer),
+      );
+      return true;
+    },
+    [groupCode, queryClient],
+  );
+
+  const handleStart = useCallback(
+    (body: StartPomodoroRequest) => {
+      if (!groupCode) return;
+      startPomodoro(body);
+    },
+    [groupCode, startPomodoro],
+  );
+
+  const handlePause = useCallback(() => {
+    if (!groupCode) return;
+    pausePomodoro();
+  }, [groupCode, pausePomodoro]);
+
+  const handleResume = useCallback(() => {
+    if (!groupCode) return;
+    resumePomodoro();
+  }, [groupCode, resumePomodoro]);
+
+  const handleStop = useCallback(() => {
+    if (!groupCode) return;
+    stopPomodoro();
+  }, [groupCode, stopPomodoro]);
+
+  return {
+    pomodoroStatus,
+    isStartingPomodoro,
+    isPausingPomodoro,
+    isResumingPomodoro,
+    isStoppingPomodoro,
+    applyLiveKitSync,
+    handleStart,
+    handlePause,
+    handleResume,
+    handleStop,
+  };
+}

--- a/frontend/src/pages/Room/hooks/useRoomReactions.ts
+++ b/frontend/src/pages/Room/hooks/useRoomReactions.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { getReactions, sendReaction } from "@/apis/domains/livekit/api";
+import { isLiveKitReactionMessage } from "@/apis/domains/livekit/reactionSync";
+import type { Reaction } from "@/apis/domains/livekit/type";
+import type { ReactionItem } from "@/pages/Room/components/ReactionFloater";
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
+
+const REACTION_DISPLAY_MS = 3000;
+const REACTION_LEFT_MIN_PERCENT = 10;
+const REACTION_LEFT_MAX_PERCENT = 80;
+
+export function useRoomReactions(groupCode: string | undefined) {
+  const { data: reactions = [] } = useQuery({
+    queryKey: QUERY_KEYS.livekit.reactions(groupCode ?? ""),
+    queryFn: () => getReactions(groupCode!),
+    enabled: !!groupCode,
+  });
+
+  const { mutate: sendEmojiReaction } = useMutation({
+    mutationFn: (reaction: Reaction) =>
+      sendReaction(groupCode!, { emoji: reaction.name }),
+    onError: (error) => {
+      console.error("이모지 전송 실패", error);
+    },
+  });
+
+  const [receivedReactions, setReceivedReactions] = useState<ReactionItem[]>(
+    [],
+  );
+  const reactionTimeoutsRef = useRef<number[]>([]);
+
+  useEffect(() => {
+    return () => {
+      reactionTimeoutsRef.current.forEach((timeoutId) => {
+        window.clearTimeout(timeoutId);
+      });
+      reactionTimeoutsRef.current = [];
+    };
+  }, []);
+
+  const handleSendReaction = useCallback(
+    (reaction: Reaction) => {
+      if (!groupCode) return;
+      sendEmojiReaction(reaction);
+    },
+    [groupCode, sendEmojiReaction],
+  );
+
+  const applyLiveKitReaction = useCallback((data: unknown) => {
+    if (!isLiveKitReactionMessage(data)) return;
+
+    const id = Date.now() + Math.random();
+    const left =
+      REACTION_LEFT_MIN_PERCENT +
+      Math.random() * (REACTION_LEFT_MAX_PERCENT - REACTION_LEFT_MIN_PERCENT);
+
+    setReceivedReactions((prev) => [...prev, { ...data, id, left }]);
+
+    const timeoutId = window.setTimeout(() => {
+      setReceivedReactions((prev) => prev.filter((r) => r.id !== id));
+      reactionTimeoutsRef.current = reactionTimeoutsRef.current.filter(
+        (savedId) => savedId !== timeoutId,
+      );
+    }, REACTION_DISPLAY_MS);
+    reactionTimeoutsRef.current.push(timeoutId);
+  }, []);
+
+  return {
+    reactions,
+    receivedReactions,
+    handleSendReaction,
+    applyLiveKitReaction,
+  };
+}

--- a/frontend/src/pages/Room/index.tsx
+++ b/frontend/src/pages/Room/index.tsx
@@ -1,322 +1,37 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useNavigate, useParams } from "react-router-dom";
-import { PATHS } from "@/routes/path";
+import { useState } from "react";
+import { useParams } from "react-router-dom";
 import BottomBar from "@/pages/Room/components/BottomBar/BottomBar";
 import TopBar from "@/pages/Room/components/TopBar/TopBar";
-import Pomodoro from "@/pages/Room/components/Cam/Pomodoro";
 import CamLayout from "@/pages/Room/components/Cam/CamLayout";
 import TodoCamCard from "@/pages/Room/components/todo/TodoCamCard";
-import VideoTile from "@/pages/Room/components/Cam/VideoTile";
-
-import {
-  getLiveKitToken,
-  getReactions,
-  sendReaction,
-} from "@/apis/domains/livekit/api";
-import type { Reaction, LiveKitReactionMessage } from "@/apis/domains/livekit/type";
-import {
-  isLiveKitPomodoroSyncMessage,
-  toPomodoroStatusResponse,
-} from "@/apis/domains/livekit/pomodoroSync";
 import ReactionFloater from "@/pages/Room/components/ReactionFloater";
-import type { ReactionItem } from "@/pages/Room/components/ReactionFloater";
-import { QUERY_KEYS } from "@/apis/constants/queryKeys";
-import { useLiveKit } from "@/hooks/useLiveKit";
-import { LIVEKIT_URL } from "@/apis/constants/endpoints";
-import { groupApi } from "@/apis/domains/group/api";
-import { userApi } from "@/apis/domains/user/api";
-import { usePomodoroStatus } from "@/hooks/usePomodoroStatus";
-import { useStartPomodoro } from "@/hooks/useStartPomodoro";
-import { usePausePomodoro } from "@/hooks/usePausePomodoro";
-import { useResumePomodoro } from "@/hooks/useResumePomodoro";
-import { useStopPomodoro } from "@/hooks/useStopPomodoro";
-
-type PomodoroConfig = {
-  studyMinutes: number;
-  breakMinutes: number;
-  repeat: number;
-  enabled: boolean;
-};
-
-const isLiveKitReactionMessage = (
-  value: unknown,
-): value is LiveKitReactionMessage => {
-  if (!value || typeof value !== "object") return false;
-  const candidate = value as Partial<LiveKitReactionMessage>;
-  return (
-    typeof candidate.emoji === "string" &&
-    typeof candidate.emojiChar === "string" &&
-    typeof candidate.senderNickname === "string"
-  );
-};
-
-const getProfileImageUrl = (value: unknown): string | null => {
-  if (!value || typeof value !== "object") return null;
-
-  const candidate = value as Record<string, unknown>;
-  const imageUrl =
-    candidate.imageUrl ??
-    candidate.profileImageUrl ??
-    candidate.profileImage ??
-    candidate.avatarUrl ??
-    candidate.picture;
-
-  return typeof imageUrl === "string" && imageUrl.trim() ? imageUrl : null;
-};
-
-const getParticipantMatchKeys = (value: unknown): string[] => {
-  if (!value || typeof value !== "object") return [];
-
-  const candidate = value as Record<string, unknown>;
-  return [
-    candidate.id,
-    candidate.memberId,
-    candidate.userId,
-    candidate.nickname,
-    candidate.name,
-    candidate.email,
-    candidate.identity,
-  ]
-    .filter(
-      (key): key is string | number =>
-        typeof key === "string" || typeof key === "number",
-    )
-    .map(String);
-};
+import RoomPomodoro from "@/pages/Room/components/RoomPomodoro";
+import {
+  useRoomLiveKit,
+  useRoomLiveKitData,
+  useRoomParticipants,
+} from "@/pages/Room/hooks";
 
 const RoomPage = () => {
-  const navigate = useNavigate();
   const { groupCode } = useParams();
-  const queryClient = useQueryClient();
+  const [todoOpen, setTodoOpen] = useState(false);
 
-  const { data: reactions = [] } = useQuery({
-    queryKey: QUERY_KEYS.livekit.reactions(groupCode ?? ""),
-    queryFn: () => getReactions(groupCode!),
-    enabled: !!groupCode,
-  });
+  const { pomodoro, reactions, handleDataReceived } =
+    useRoomLiveKitData(groupCode);
 
-  const { mutate: sendEmojiReaction } = useMutation({
-    mutationFn: (reaction: Reaction) =>
-      sendReaction(groupCode!, { emoji: reaction.name }),
-    onError: (error) => {
-      console.error("이모지 전송 실패", error);
-    },
-  });
-
-  const handleSendReaction = (reaction: Reaction) => {
-    if (!groupCode) return;
-    sendEmojiReaction(reaction);
-  };
-  const { data: groupMembers = [] } = useQuery({
-    queryKey: QUERY_KEYS.groups.members(groupCode ?? ""),
-    queryFn: () => groupApi.getGroupMembers(groupCode!),
-    enabled: !!groupCode,
-  });
-  const { data: currentMember } = useQuery({
-    queryKey: QUERY_KEYS.member.me,
-    queryFn: userApi.get,
-  });
-
-  const { data: pomodoroStatus } = usePomodoroStatus({
-    groupCode,
-    enabled: !!groupCode,
-  });
-  const { mutate: startPomodoro, isPending: isStartingPomodoro } =
-    useStartPomodoro(groupCode);
-  const { mutate: pausePomodoro, isPending: isPausingPomodoro } =
-    usePausePomodoro(groupCode);
-  const { mutate: resumePomodoro, isPending: isResumingPomodoro } =
-    useResumePomodoro(groupCode);
-  const { mutate: stopPomodoro, isPending: isStoppingPomodoro } =
-    useStopPomodoro(groupCode);
-  const [token, setToken] = useState<string | null>(null); //livekit 토큰
-  const [, setLivekitTestStatus] = useState(""); //테스트 상태메세지
-  const [receivedReactions, setReceivedReactions] = useState<ReactionItem[]>([]);
-  const reactionTimeoutsRef = useRef<number[]>([]);
-
-  useEffect(() => {
-    return () => {
-      reactionTimeoutsRef.current.forEach((timeoutId) => {
-        window.clearTimeout(timeoutId);
-      });
-      reactionTimeoutsRef.current = [];
-    };
-  }, []);
-
-  const handleDataReceived = useCallback(
-    (payload: Uint8Array) => {
-      try {
-        const text = new TextDecoder().decode(payload);
-        const data = JSON.parse(text);
-
-        if (isLiveKitPomodoroSyncMessage(data)) {
-          if (!groupCode) return;
-          queryClient.setQueryData(
-            QUERY_KEYS.pomodoro.status(groupCode),
-            toPomodoroStatusResponse(data.timer),
-          );
-          return;
-        }
-
-        if (!isLiveKitReactionMessage(data)) return;
-
-        const id = Date.now() + Math.random();
-        const left = 10 + Math.random() * 70; // 10% ~ 80% 사이 랜덤 X
-        setReceivedReactions((prev) => [...prev, { ...data, id, left }]);
-
-        const timeoutId = window.setTimeout(() => {
-          setReceivedReactions((prev) => prev.filter((r) => r.id !== id));
-          reactionTimeoutsRef.current = reactionTimeoutsRef.current.filter(
-            (savedId) => savedId !== timeoutId,
-          );
-        }, 3000);
-        reactionTimeoutsRef.current.push(timeoutId);
-      } catch {
-        // 파싱 불가한 메시지는 무시
-      }
-    },
-    [groupCode, queryClient],
-  );
-
-  //token && serverUrl 있을 때만 연결
   const {
-    isConnected,
-    participants: remoteParticipants,
-    room,
-    error,
+    remoteParticipants,
     isMicrophoneEnabled,
     isCameraEnabled,
     isMediaTogglePending,
     toggleMicrophone,
     toggleCamera,
-  } = useLiveKit({
-    serverUrl: token ? LIVEKIT_URL : "",
-    token: token || "",
-    onDataReceived: handleDataReceived,
-  });
+    handleLeaveRoom,
+  } = useRoomLiveKit(groupCode, handleDataReceived);
 
-  //나가기 핸들러
-  const handleLeaveRoom = () => {
-    if (room) {
-      room.disconnect();
-    }
-    navigate(PATHS.HOME);
-  };
-
-  //방 진입 시 즉시 연결
-  useEffect(() => {
-    if (!groupCode) return;
-    const run = async () => {
-      setLivekitTestStatus("토큰 요청하는 중");
-      try {
-        const newToken = await getLiveKitToken(groupCode);
-        setToken(newToken);
-        setLivekitTestStatus("토큰 발급 성공");
-      } catch (err) {
-        setLivekitTestStatus(`토큰 발급 에러: ${String(err)}`);
-      }
-    };
-    run();
-  }, [groupCode]);
-
-  //연결 상태 출력
-  useEffect(() => {
-    if (isConnected) {
-      setLivekitTestStatus("livekit 연결 성공");
-    }
-  }, [isConnected, remoteParticipants]);
-
-  //에러
-  useEffect(() => {
-    if (error) {
-      setLivekitTestStatus(`livekit 연결 실패: ${error.message}`);
-      console.error("livekit 에러", error);
-    }
-  }, [error]);
-
-  const groupMemberByKey = useMemo(() => {
-    const map = new Map<string, (typeof groupMembers)[number]>();
-
-    groupMembers.forEach((member) => {
-      getParticipantMatchKeys(member).forEach((key) => {
-        map.set(key, member);
-      });
-    });
-
-    return map;
-  }, [groupMembers]);
-
-  // participants 참가자 목록
-  const allParticipants = remoteParticipants.map((p) => {
-    const isCurrentParticipant =
-      p.identity === String(currentMember?.id) ||
-      p.identity === currentMember?.email ||
-      p.name === currentMember?.nickname;
-    const matchedGroupMember =
-      groupMemberByKey.get(p.identity) ??
-      groupMemberByKey.get(p.name) ??
-      (isCurrentParticipant ? currentMember : undefined);
-    const profileImageUrl =
-      p.imageUrl ??
-      getProfileImageUrl(matchedGroupMember) ??
-      (isCurrentParticipant ? getProfileImageUrl(currentMember) : null);
-    const hasVideo = p.isVideoEnabled && p.videoTrack;
-
-    return {
-      id: p.identity,
-      name: p.name,
-      isMuted: p.isMuted,
-      profileImageUrl,
-      video: hasVideo ? (
-        <VideoTile
-          videoTrack={p.videoTrack ?? undefined}
-          audioTrack={p.audioTrack ?? undefined}
-        />
-      ) : undefined,
-      audio: !hasVideo ? (
-        <VideoTile audioTrack={p.audioTrack ?? undefined} />
-      ) : undefined,
-    };
-  });
-
-  const [todoOpen, setTodoOpen] = useState(false);
-
-  const DEFAULT_FOCUS_MINUTES = 45;
-  const DEFAULT_BREAK_MINUTES = 15;
-  const DEFAULT_TOTAL_ROUNDS = 1;
-
-  const isPomodoroRunning =
-    pomodoroStatus?.status === "RUNNING" ||
-    pomodoroStatus?.status === "BREAK" ||
-    pomodoroStatus?.status === "PAUSED";
-
-  const pomodoroNode = (
-    <Pomodoro
-      studyMinutes={
-        isPomodoroRunning
-          ? (pomodoroStatus?.focusMinutes ?? DEFAULT_FOCUS_MINUTES)
-          : DEFAULT_FOCUS_MINUTES
-      }
-      breakMinutes={
-        isPomodoroRunning
-          ? (pomodoroStatus?.breakMinutes ?? DEFAULT_BREAK_MINUTES)
-          : DEFAULT_BREAK_MINUTES
-      }
-      repeat={
-        isPomodoroRunning
-          ? (pomodoroStatus?.totalRounds ?? DEFAULT_TOTAL_ROUNDS)
-          : DEFAULT_TOTAL_ROUNDS
-      }
-      autoStart={isPomodoroRunning && pomodoroStatus?.status !== "PAUSED"}
-      serverNow={isPomodoroRunning ? pomodoroStatus?.serverNow : undefined}
-      phase={isPomodoroRunning ? pomodoroStatus?.phase : undefined}
-      focusEndsAt={isPomodoroRunning ? pomodoroStatus?.focusEndsAt : undefined}
-      breakEndsAt={isPomodoroRunning ? pomodoroStatus?.breakEndsAt : undefined}
-      currentRound={
-        isPomodoroRunning ? (pomodoroStatus?.currentRound ?? 1) : 1
-      }
-    />
+  const { groupMembers, participants } = useRoomParticipants(
+    groupCode,
+    remoteParticipants,
   );
 
   return (
@@ -325,16 +40,19 @@ const RoomPage = () => {
         isTodoOpen={todoOpen}
         onToggleTodo={() => setTodoOpen((prev) => !prev)}
       />
+
       <div className="flex flex-1 overflow-hidden">
         <div
           className={`flex items-center justify-center flex-1 min-w-0 transition-all duration-300 ease-out ${
             todoOpen ? "ml-20 mr-4" : "mx-20"
           }`}
         >
-          <CamLayout participants={allParticipants} pomodoro={pomodoroNode} />
+          <CamLayout
+            participants={participants}
+            pomodoro={<RoomPomodoro pomodoroStatus={pomodoro.pomodoroStatus} />}
+          />
         </div>
 
-        {/* 투두 패널 */}
         <div
           className={`shrink-0 overflow-hidden transition-[width] duration-300 ease-out ${
             todoOpen ? "w-[480px]" : "w-0"
@@ -349,32 +67,21 @@ const RoomPage = () => {
           </div>
         </div>
       </div>
-      <ReactionFloater reactions={receivedReactions} />
+
+      <ReactionFloater reactions={reactions.receivedReactions} />
 
       <BottomBar
-        reactions={reactions}
-        onSendReaction={handleSendReaction}
-        pomodoroStatus={pomodoroStatus?.status}
-        isStartingPomodoro={isStartingPomodoro}
-        isPausingPomodoro={isPausingPomodoro}
-        isResumingPomodoro={isResumingPomodoro}
-        isStoppingPomodoro={isStoppingPomodoro}
-        onPomodoroStart={(body) => {
-          if (!groupCode) return;
-          startPomodoro(body);
-        }}
-        onPomodoroPause={() => {
-          if (!groupCode) return;
-          pausePomodoro();
-        }}
-        onPomodoroResume={() => {
-          if (!groupCode) return;
-          resumePomodoro();
-        }}
-        onPomodoroStop={() => {
-          if (!groupCode) return;
-          stopPomodoro();
-        }}
+        reactions={reactions.reactions}
+        onSendReaction={reactions.handleSendReaction}
+        pomodoroStatus={pomodoro.pomodoroStatus?.status}
+        isStartingPomodoro={pomodoro.isStartingPomodoro}
+        isPausingPomodoro={pomodoro.isPausingPomodoro}
+        isResumingPomodoro={pomodoro.isResumingPomodoro}
+        isStoppingPomodoro={pomodoro.isStoppingPomodoro}
+        onPomodoroStart={pomodoro.handleStart}
+        onPomodoroPause={pomodoro.handlePause}
+        onPomodoroResume={pomodoro.handleResume}
+        onPomodoroStop={pomodoro.handleStop}
         onToggleMic={toggleMicrophone}
         onToggleCam={toggleCamera}
         isMicOn={isMicrophoneEnabled}

--- a/frontend/src/pages/Room/index.tsx
+++ b/frontend/src/pages/Room/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import { PATHS } from "@/routes/path";
 import BottomBar from "@/pages/Room/components/BottomBar/BottomBar";
@@ -15,6 +15,10 @@ import {
   sendReaction,
 } from "@/apis/domains/livekit/api";
 import type { Reaction, LiveKitReactionMessage } from "@/apis/domains/livekit/type";
+import {
+  isLiveKitPomodoroSyncMessage,
+  toPomodoroStatusResponse,
+} from "@/apis/domains/livekit/pomodoroSync";
 import ReactionFloater from "@/pages/Room/components/ReactionFloater";
 import type { ReactionItem } from "@/pages/Room/components/ReactionFloater";
 import { QUERY_KEYS } from "@/apis/constants/queryKeys";
@@ -84,6 +88,7 @@ const getParticipantMatchKeys = (value: unknown): string[] => {
 const RoomPage = () => {
   const navigate = useNavigate();
   const { groupCode } = useParams();
+  const queryClient = useQueryClient();
 
   const { data: reactions = [] } = useQuery({
     queryKey: QUERY_KEYS.livekit.reactions(groupCode ?? ""),
@@ -139,27 +144,40 @@ const RoomPage = () => {
     };
   }, []);
 
-  const handleDataReceived = useCallback((payload: Uint8Array) => {
-    try {
-      const text = new TextDecoder().decode(payload);
-      const data = JSON.parse(text);
-      if (!isLiveKitReactionMessage(data)) return;
+  const handleDataReceived = useCallback(
+    (payload: Uint8Array) => {
+      try {
+        const text = new TextDecoder().decode(payload);
+        const data = JSON.parse(text);
 
-      const id = Date.now() + Math.random();
-      const left = 10 + Math.random() * 70; // 10% ~ 80% 사이 랜덤 X
-      setReceivedReactions((prev) => [...prev, { ...data, id, left }]);
+        if (isLiveKitPomodoroSyncMessage(data)) {
+          if (!groupCode) return;
+          queryClient.setQueryData(
+            QUERY_KEYS.pomodoro.status(groupCode),
+            toPomodoroStatusResponse(data.timer),
+          );
+          return;
+        }
 
-      const timeoutId = window.setTimeout(() => {
-        setReceivedReactions((prev) => prev.filter((r) => r.id !== id));
-        reactionTimeoutsRef.current = reactionTimeoutsRef.current.filter(
-          (savedId) => savedId !== timeoutId,
-        );
-      }, 3000);
-      reactionTimeoutsRef.current.push(timeoutId);
-    } catch {
-      // 파싱 불가한 메시지는 무시
-    }
-  }, []);
+        if (!isLiveKitReactionMessage(data)) return;
+
+        const id = Date.now() + Math.random();
+        const left = 10 + Math.random() * 70; // 10% ~ 80% 사이 랜덤 X
+        setReceivedReactions((prev) => [...prev, { ...data, id, left }]);
+
+        const timeoutId = window.setTimeout(() => {
+          setReceivedReactions((prev) => prev.filter((r) => r.id !== id));
+          reactionTimeoutsRef.current = reactionTimeoutsRef.current.filter(
+            (savedId) => savedId !== timeoutId,
+          );
+        }, 3000);
+        reactionTimeoutsRef.current.push(timeoutId);
+      } catch {
+        // 파싱 불가한 메시지는 무시
+      }
+    },
+    [groupCode, queryClient],
+  );
 
   //token && serverUrl 있을 때만 연결
   const {

--- a/frontend/src/pages/Room/utils/participantUtils.ts
+++ b/frontend/src/pages/Room/utils/participantUtils.ts
@@ -1,0 +1,33 @@
+export const getProfileImageUrl = (value: unknown): string | null => {
+  if (!value || typeof value !== "object") return null;
+
+  const candidate = value as Record<string, unknown>;
+  const imageUrl =
+    candidate.imageUrl ??
+    candidate.profileImageUrl ??
+    candidate.profileImage ??
+    candidate.avatarUrl ??
+    candidate.picture;
+
+  return typeof imageUrl === "string" && imageUrl.trim() ? imageUrl : null;
+};
+
+export const getParticipantMatchKeys = (value: unknown): string[] => {
+  if (!value || typeof value !== "object") return [];
+
+  const candidate = value as Record<string, unknown>;
+  return [
+    candidate.id,
+    candidate.memberId,
+    candidate.userId,
+    candidate.nickname,
+    candidate.name,
+    candidate.email,
+    candidate.identity,
+  ]
+    .filter(
+      (key): key is string | number =>
+        typeof key === "string" || typeof key === "number",
+    )
+    .map(String);
+};


### PR DESCRIPTION
# 변경점 👍
- LiveKit `DataReceived`에서 `type: "pomodoro.sync"` 메시지 처리
- `timer` payload를 `PomodoroStatusResponse`로 변환 후 `queryClient.setQueryData`로 캐시 갱신
- 이모지(`reaction`)와 동일한 LiveKit push 경로로 실시간 동기화
 