### PR TITLE
feat: 방 상단바 D-day 및 목표 공부시간 API 연동

### DIFF
--- a/frontend/src/hooks/useMember.ts
+++ b/frontend/src/hooks/useMember.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { userApi } from "@/apis/domains/user/api";
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
+
+export function useMember() {
+  return useQuery({
+    queryKey: QUERY_KEYS.member.me,
+    queryFn: userApi.get,
+  });
+}

--- a/frontend/src/pages/Home/components/ProfileCard.tsx
+++ b/frontend/src/pages/Home/components/ProfileCard.tsx
@@ -1,11 +1,9 @@
 import { useState, useEffect } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { Settings, MessageCircle } from "lucide-react";
 import Avatar from "@/components/Avatar";
 import SettingsModal from "@/pages/Home/components/Modals/ProfileSettingsModal";
-import { userApi } from "@/apis/domains/user/api";
-import { QUERY_KEYS } from "@/apis/constants/queryKeys";
-import { formatDisplayDate, getDaysUntilDDay } from "@/utils/date";
+import { useMember } from "@/hooks/useMember";
+import { formatDisplayDate, formatDDayLabel } from "@/utils/date";
 import { formatStudyGoalDisplay } from "@/utils/studyGoalTime";
 
 interface ProfileCardProps {
@@ -25,10 +23,7 @@ const ProfileCard = ({
     isLoading,
     isError,
     refetch,
-  } = useQuery({
-    queryKey: QUERY_KEYS.member.me,
-    queryFn: userApi.get,
-  });
+  } = useMember();
 
   useEffect(() => {
     if (initialSettingsOpen && oauthFirstTimeUser) {
@@ -37,7 +32,7 @@ const ProfileCard = ({
     }
   }, [initialSettingsOpen, oauthFirstTimeUser]);
 
-  const daysLeft = member ? getDaysUntilDDay(member.dDayDate) : null;
+  const dDayLabel = formatDDayLabel(member?.dDayDate);
   const targetDateLabel = member ? formatDisplayDate(member.dDayDate) : "—";
   const examName = member?.dDayTitle?.trim() || "미설정";
   const displayName = member?.nickname?.trim() || member?.email || "—";
@@ -103,13 +98,7 @@ const ProfileCard = ({
             <span className="font-medium">{targetDateLabel}</span>
             <span className="font-normal">까지</span>
           </div>
-          <span className="text-white text-h1 font-bold">
-            {daysLeft === null
-              ? "D-?"
-              : daysLeft >= 0
-                ? `D-${daysLeft}`
-                : `D+${Math.abs(daysLeft)}`}
-          </span>
+          <span className="text-white text-h1 font-bold">{dDayLabel}</span>
           <span className="text-white text-bodySm">{examName}</span>
         </div>
       </div>

--- a/frontend/src/pages/Room/components/TopBar/TopBar.tsx
+++ b/frontend/src/pages/Room/components/TopBar/TopBar.tsx
@@ -1,11 +1,9 @@
 import CustomBtn from "@/pages/Room/components/CustomBtn";
 import { useState, useEffect } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { Play, ListChecks, Settings } from "lucide-react";
 import { Link } from "react-router-dom";
 import { PATHS } from "@/routes/path";
-import { userApi } from "@/apis/domains/user/api";
-import { QUERY_KEYS } from "@/apis/constants/queryKeys";
+import { useMember } from "@/hooks/useMember";
 import { getDDayDisplayParts } from "@/utils/date";
 import { formatStudyGoalAsClock } from "@/utils/studyGoalTime";
 
@@ -22,10 +20,7 @@ type TopBarProps = {
 };
 
 export default function TopBar({ isTodoOpen = false, onToggleTodo }: TopBarProps) {
-  const { data: member } = useQuery({
-    queryKey: QUERY_KEYS.member.me,
-    queryFn: userApi.get,
-  });
+  const { data: member } = useMember();
 
   const { sign: dDaySign, days: dDayDays } = getDDayDisplayParts(member?.dDayDate);
   const totalTime = formatStudyGoalAsClock(member?.weeklyStudyTimeGoal);

--- a/frontend/src/pages/Room/components/TopBar/TopBar.tsx
+++ b/frontend/src/pages/Room/components/TopBar/TopBar.tsx
@@ -1,8 +1,13 @@
 import CustomBtn from "@/pages/Room/components/CustomBtn";
 import { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Play, ListChecks, Settings } from "lucide-react";
 import { Link } from "react-router-dom";
 import { PATHS } from "@/routes/path";
+import { userApi } from "@/apis/domains/user/api";
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
+import { getDDayDisplayParts } from "@/utils/date";
+import { formatStudyGoalAsClock } from "@/utils/studyGoalTime";
 
 function formatTime(seconds: number) {
   const h = Math.floor(seconds / 3600);
@@ -17,23 +22,26 @@ type TopBarProps = {
 };
 
 export default function TopBar({ isTodoOpen = false, onToggleTodo }: TopBarProps) {
-  const [dDay] = useState(23);
+  const { data: member } = useQuery({
+    queryKey: QUERY_KEYS.member.me,
+    queryFn: userApi.get,
+  });
+
+  const { sign: dDaySign, days: dDayDays } = getDDayDisplayParts(member?.dDayDate);
+  const totalTime = formatStudyGoalAsClock(member?.weeklyStudyTimeGoal);
 
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setElapsedSeconds(prev => prev + 1);
+      setElapsedSeconds((prev) => prev + 1);
     }, 1000);
 
     return () => clearInterval(interval);
   }, []);
 
-  const totalTime = "4:00:00";
-
   return (
     <div className="flex items-center justify-between w-full h-20 gap-4 px-6">
-
       <div className="flex items-center h-full gap-5">
         <Link
           to={PATHS.HOME}
@@ -45,14 +53,16 @@ export default function TopBar({ isTodoOpen = false, onToggleTodo }: TopBarProps
 
         <div className="flex flex-col justify-center h-full leading-5.5 relative bottom-[2px] text-white">
           <div className="flex gap-1 ml-0.5 text-bodyMd items-center">
-            <div>D -</div>
-            <div className="text-[#4CAF50]">{dDay}</div>
+            <div>D {dDaySign}</div>
+            <div className="text-[#4CAF50]">{dDayDays}</div>
           </div>
 
           <div className="flex items-center gap-1.5">
             <Play size={15} className="relative top-[2px]" />
             <div className="flex items-baseline gap-1 leading-none relative top-[1px]">
-              <div className="ml-1 font-semibold text-h3">{formatTime(elapsedSeconds)}</div>
+              <div className="ml-1 font-semibold text-h3">
+                {formatTime(elapsedSeconds)}
+              </div>
               <div className="text-bodyMd">/ {totalTime}</div>
             </div>
           </div>

--- a/frontend/src/pages/Room/hooks/useRoomParticipants.tsx
+++ b/frontend/src/pages/Room/hooks/useRoomParticipants.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/pages/Room/utils/participantUtils";
 import { QUERY_KEYS } from "@/apis/constants/queryKeys";
 import { groupApi } from "@/apis/domains/group/api";
-import { userApi } from "@/apis/domains/user/api";
+import { useMember } from "@/hooks/useMember";
 import type { ParticipantData } from "@/types/livekit";
 
 export function useRoomParticipants(
@@ -20,10 +20,7 @@ export function useRoomParticipants(
     enabled: !!groupCode,
   });
 
-  const { data: currentMember } = useQuery({
-    queryKey: QUERY_KEYS.member.me,
-    queryFn: userApi.get,
-  });
+  const { data: currentMember } = useMember();
 
   const groupMemberByKey = useMemo(() => {
     const map = new Map<string, (typeof groupMembers)[number]>();

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -18,7 +18,6 @@ export type DDayDisplayParts = {
   days: string;
 };
 
-/** TopBar 등 D-23 / D+123 / D-? 분리 표시용 */
 export function getDDayDisplayParts(
   iso: string | null | undefined,
 ): DDayDisplayParts {
@@ -26,4 +25,10 @@ export function getDDayDisplayParts(
   if (daysLeft === null) return { sign: "-", days: "?" };
   if (daysLeft >= 0) return { sign: "-", days: String(daysLeft) };
   return { sign: "+", days: String(Math.abs(daysLeft)) };
+}
+
+export function formatDDayLabel(iso: string | null | undefined): string {
+  const { sign, days } = getDDayDisplayParts(iso);
+  if (days === "?") return "D-?";
+  return `D${sign}${days}`;
 }

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -12,3 +12,18 @@ export function getDaysUntilDDay(iso: string | null): number | null {
   if (!target.isValid()) return null;
   return target.diff(dayjs().startOf("day"), "day");
 }
+
+export type DDayDisplayParts = {
+  sign: "-" | "+";
+  days: string;
+};
+
+/** TopBar 등 D-23 / D+123 / D-? 분리 표시용 */
+export function getDDayDisplayParts(
+  iso: string | null | undefined,
+): DDayDisplayParts {
+  const daysLeft = getDaysUntilDDay(iso ?? null);
+  if (daysLeft === null) return { sign: "-", days: "?" };
+  if (daysLeft >= 0) return { sign: "-", days: String(daysLeft) };
+  return { sign: "+", days: String(Math.abs(daysLeft)) };
+}

--- a/frontend/src/utils/studyGoalTime.ts
+++ b/frontend/src/utils/studyGoalTime.ts
@@ -9,7 +9,9 @@ export function normalizeStudyGoalMinutes(minutes: number): number {
   return Math.min(55, Math.max(0, Math.round(minutes / 5) * 5));
 }
 
-export function parseStudyGoal(value: string | null | undefined): StudyGoalParts {
+export function parseStudyGoal(
+  value: string | null | undefined,
+): StudyGoalParts {
   const trimmed = value?.trim() ?? "";
   if (!trimmed) return { hours: 0, minutes: 0 };
 
@@ -67,7 +69,16 @@ export function serializeStudyGoal(
   return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
 }
 
-export function formatStudyGoalDisplay(value: string | null | undefined): string {
+export function formatStudyGoalDisplay(
+  value: string | null | undefined,
+): string {
   const { hours, minutes } = parseStudyGoal(value);
   return formatStudyGoal(hours, minutes) || value?.trim() || "미설정";
+}
+
+export function formatStudyGoalAsClock(
+  value: string | null | undefined,
+): string {
+  const { hours, minutes } = parseStudyGoal(value);
+  return `${hours}:${String(minutes).padStart(2, "0")}:00`;
 }


### PR DESCRIPTION
# 변경점 👍
- TopBar에 내 정보 API(`member/me`) D-day·주간 목표 공부시간 연동
- D-day 지난 경우 `D + N` 표시, 미설정 시 `D - ?` 표시
- `useMember` 훅 추가 및 TopBar·ProfileCard·useRoomParticipants 적용
- D-day 표시 로직 `formatDDayLabel` / `getDDayDisplayParts`로 통합