### PR TITLE
feat: 푸터 및 개인정보처리방침 모달 추가

### DIFF
--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import PrivacyPolicyModal from "@/components/Footer/PrivacyPolicyModal";
+
+type FooterProps = {
+  variant?: "dark" | "light";
+};
+
+const variantStyles = {
+  dark: {
+    bg: "bg-gray-darkest",
+    brand: "text-white",
+    muted: "text-gray-semidark",
+    link: "text-gray-semidark hover:text-white/80",
+    separator: "text-gray-semidark",
+  },
+  light: {
+    bg: "bg-[#e7ecea]",
+    brand: "text-[#222222]",
+    muted: "text-gray-semidark",
+    link: "text-gray-semidark hover:text-[#222222]",
+    separator: "text-gray-semidark",
+  },
+} as const;
+
+export default function Footer({ variant = "dark" }: FooterProps) {
+  const [isPrivacyOpen, setIsPrivacyOpen] = useState(false);
+  const styles = variantStyles[variant];
+
+  return (
+    <>
+      <footer className={`w-full shrink-0 ${styles.bg} px-16 py-10`}>
+        <div className="flex items-end justify-between gap-8">
+          <div>
+            <p className={`text-h2 font-bold leading-none ${styles.brand}`}>
+              GRIT
+            </p>
+            <p className={`mt-3 text-bodySm ${styles.muted}`}>
+              공간을 넘어 이어지는 우리만의 독서실
+            </p>
+          </div>
+
+          <div
+            className={`flex shrink-0 items-center gap-3 text-bodySm ${styles.muted}`}
+          >
+            <span>© 2026 GRIT</span>
+            <span className={styles.separator}>|</span>
+            <button
+              type="button"
+              onClick={() => setIsPrivacyOpen(true)}
+              className={`${styles.link} transition-colors`}
+            >
+              개인정보처리방침
+            </button>
+          </div>
+        </div>
+      </footer>
+
+      <PrivacyPolicyModal
+        open={isPrivacyOpen}
+        onClose={() => setIsPrivacyOpen(false)}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/Footer/PrivacyPolicyModal.tsx
+++ b/frontend/src/components/Footer/PrivacyPolicyModal.tsx
@@ -1,0 +1,161 @@
+import Modal from "@/components/Modal";
+
+type PrivacyPolicyModalProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export default function PrivacyPolicyModal({
+  open,
+  onClose,
+}: PrivacyPolicyModalProps) {
+  return (
+    <Modal isOpen={open} onClose={onClose}>
+      <Modal.Overlay />
+      <Modal.Content className="w-[640px]">
+        <Modal.CloseButton />
+        <Modal.Header className="flex flex-col items-center text-center">
+          <Modal.Title size="sm" />
+          <p className="mt-2 text-sm font-medium text-[#D6FDE5]">
+            개인정보 처리방침
+          </p>
+        </Modal.Header>
+
+        <Modal.Body className="max-h-[min(70vh,640px)] overflow-y-auto px-6 pb-8 text-bodySm text-[#D6FDE5]/85">
+          <p className="leading-relaxed">
+            <strong className="text-[#D6FDE5]">GRIT</strong>
+            (
+            <a
+              href="https://grit-sigma.vercel.app/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-green-normal underline underline-offset-2 hover:text-green-light"
+            >
+              https://grit-sigma.vercel.app/
+            </a>
+            )은(는) 정보주체의 자유와 권리 보호를 위해 「개인정보 보호법」 및
+            관계 법령이 정한 바를 준수하여, 적법하게 개인정보를 처리하고
+            안전하게 관리하고 있습니다.
+          </p>
+
+          <p className="mt-4 leading-relaxed">
+            이에 「개인정보 보호법」 제30조에 따라 정보주체에게 개인정보의
+            처리와 보호에 관한 절차 및 기준을 안내하고, 이와 관련한 고충을
+            신속하고 원활하게 처리할 수 있도록 하기 위하여 다음과 같이
+            개인정보 처리방침을 수립·공개합니다.
+          </p>
+
+          <p className="mt-4 text-[#D6FDE5]/60">
+            시행일: 2026-06-28 | 버전: 1.0
+          </p>
+
+          <section className="mt-6">
+            <h2 className="text-bodyMd font-semibold text-[#D6FDE5]">
+              1. 개인정보의 처리 목적
+            </h2>
+            <p className="mt-2 leading-relaxed">
+              GRIT은(는) 다음의 목적을 위하여 개인정보를 처리합니다.
+            </p>
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              <li>회원 가입 및 관리</li>
+              <li>서비스 제공</li>
+              <li>콘텐츠 제공</li>
+              <li>안전 및 보안</li>
+              <li>부정이용 방지</li>
+              <li>통계 분석</li>
+              <li>연구 및 개발</li>
+              <li>고객 상담</li>
+            </ul>
+          </section>
+
+          <section className="mt-6">
+            <h2 className="text-bodyMd font-semibold text-[#D6FDE5]">
+              2. 수집하는 개인정보 항목
+            </h2>
+            <p className="mt-2 leading-relaxed">
+              <strong className="text-[#D6FDE5]">필수 항목:</strong> 이메일
+              주소
+            </p>
+            <p className="mt-2 leading-relaxed">
+              <strong className="text-[#D6FDE5]">자동 수집 항목:</strong> IP
+              주소, 쿠키, 서비스 이용기록, 기기정보
+            </p>
+          </section>
+
+          <section className="mt-6">
+            <h2 className="text-bodyMd font-semibold text-[#D6FDE5]">
+              수집 방법
+            </h2>
+            <p className="mt-2 leading-relaxed">
+              홈페이지 회원가입, 쿠키(Cookie), IP 주소, 기기정보 수집
+            </p>
+          </section>
+
+          <section className="mt-6">
+            <h2 className="text-bodyMd font-semibold text-[#D6FDE5]">
+              개인정보의 안전성 확보조치
+            </h2>
+            <p className="mt-2 leading-relaxed">
+              <strong className="text-[#D6FDE5]">기술적 조치:</strong>
+            </p>
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              <li>개인정보 암호화</li>
+            </ul>
+          </section>
+
+          <section className="mt-6">
+            <h2 className="text-bodyMd font-semibold text-[#D6FDE5]">
+              쿠키 및 행태정보 수집
+            </h2>
+            <p className="mt-2 leading-relaxed font-medium text-[#D6FDE5]">
+              쿠키 사용
+            </p>
+            <p className="mt-2 leading-relaxed">
+              <strong className="text-[#D6FDE5]">사용 목적:</strong> 로그인
+              세션 유지
+            </p>
+            <p className="mt-2 leading-relaxed">
+              <strong className="text-[#D6FDE5]">거부 방법:</strong>
+            </p>
+            <ul className="mt-2 list-disc space-y-2 pl-5">
+              <li>
+                [웹 브라우저] • Chrome: 설정 &gt; 개인정보 보호 및 보안 &gt;
+                서드파티 쿠키 &gt; 서드파티 쿠키 차단 • Edge: 설정 &gt; 쿠키
+                및 사이트 권한 &gt; 쿠키 및 사이트 데이터 관리 및 삭제 •
+                Safari: 설정 &gt; Safari &gt; 고급 &gt; 모든 쿠키 차단
+              </li>
+              <li>
+                [모바일] • Android: 설정 &gt; 보안 및 개인정보 보호 &gt; 광고
+                &gt; 광고ID 삭제 • iPhone: 설정 &gt; 개인정보 보호 및 보안
+                &gt; 추적 &gt; 앱 추적 허용 해제
+              </li>
+            </ul>
+          </section>
+
+          <section className="mt-6">
+            <h2 className="text-bodyMd font-semibold text-[#D6FDE5]">
+              정보주체의 권리·의무 및 행사방법
+            </h2>
+            <p className="mt-2 leading-relaxed">
+              <strong className="text-[#D6FDE5]">권리 행사 방법:</strong>{" "}
+              website
+            </p>
+          </section>
+
+          <section className="mt-6">
+            <h2 className="text-bodyMd font-semibold text-[#D6FDE5]">
+              개인정보 처리방침의 변경
+            </h2>
+            <p className="mt-2 leading-relaxed">
+              이 개인정보 처리방침은 2026-06-28부터 적용됩니다.
+            </p>
+            <p className="mt-2 leading-relaxed">
+              <strong className="text-[#D6FDE5]">변경 고지 방법:</strong>{" "}
+              홈페이지 공지사항 게시
+            </p>
+          </section>
+        </Modal.Body>
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/frontend/src/components/Footer/PrivacyPolicyModal.tsx
+++ b/frontend/src/components/Footer/PrivacyPolicyModal.tsx
@@ -15,15 +15,12 @@ export default function PrivacyPolicyModal({
       <Modal.Content className="w-[640px]">
         <Modal.CloseButton />
         <Modal.Header className="flex flex-col items-center text-center">
-          <Modal.Title size="sm" />
-          <p className="mt-2 text-sm font-medium text-[#D6FDE5]">
-            개인정보 처리방침
-          </p>
+          <Modal.Title size="sm">개인정보 처리방침</Modal.Title>
         </Modal.Header>
 
-        <Modal.Body className="max-h-[min(70vh,640px)] overflow-y-auto px-6 pb-8 text-bodySm text-[#D6FDE5]/85">
+        <Modal.Body className="max-h-[min(70vh,640px)] overflow-y-auto px-6 pb-8 text-bodySm text-green-light/85">
           <p className="leading-relaxed">
-            <strong className="text-[#D6FDE5]">GRIT</strong>
+            <strong className="text-green-light">GRIT</strong>
             (
             <a
               href="https://grit-sigma.vercel.app/"
@@ -45,12 +42,12 @@ export default function PrivacyPolicyModal({
             개인정보 처리방침을 수립·공개합니다.
           </p>
 
-          <p className="mt-4 text-[#D6FDE5]/60">
+          <p className="mt-4 text-green-light/60">
             시행일: 2026-06-28 | 버전: 1.0
           </p>
 
           <section className="mt-6">
-            <h2 className="text-bodyMd font-semibold text-[#D6FDE5]">
+            <h2 className="text-bodyMd font-semibold text-green-light">
               1. 개인정보의 처리 목적
             </h2>
             <p className="mt-2 leading-relaxed">
@@ -69,21 +66,21 @@ export default function PrivacyPolicyModal({
           </section>
 
           <section className="mt-6">
-            <h2 className="text-bodyMd font-semibold text-[#D6FDE5]">
+            <h2 className="text-bodyMd font-semibold text-green-light">
               2. 수집하는 개인정보 항목
             </h2>
             <p className="mt-2 leading-relaxed">
-              <strong className="text-[#D6FDE5]">필수 항목:</strong> 이메일
+              <strong className="text-green-light">필수 항목:</strong> 이메일
               주소
             </p>
             <p className="mt-2 leading-relaxed">
-              <strong className="text-[#D6FDE5]">자동 수집 항목:</strong> IP
+              <strong className="text-green-light">자동 수집 항목:</strong> IP
               주소, 쿠키, 서비스 이용기록, 기기정보
             </p>
           </section>
 
           <section className="mt-6">
-            <h2 className="text-bodyMd font-semibold text-[#D6FDE5]">
+            <h2 className="text-bodyMd font-semibold text-green-light">
               수집 방법
             </h2>
             <p className="mt-2 leading-relaxed">
@@ -92,11 +89,11 @@ export default function PrivacyPolicyModal({
           </section>
 
           <section className="mt-6">
-            <h2 className="text-bodyMd font-semibold text-[#D6FDE5]">
+            <h2 className="text-bodyMd font-semibold text-green-light">
               개인정보의 안전성 확보조치
             </h2>
             <p className="mt-2 leading-relaxed">
-              <strong className="text-[#D6FDE5]">기술적 조치:</strong>
+              <strong className="text-green-light">기술적 조치:</strong>
             </p>
             <ul className="mt-2 list-disc space-y-1 pl-5">
               <li>개인정보 암호화</li>
@@ -104,18 +101,18 @@ export default function PrivacyPolicyModal({
           </section>
 
           <section className="mt-6">
-            <h2 className="text-bodyMd font-semibold text-[#D6FDE5]">
+            <h2 className="text-bodyMd font-semibold text-green-light">
               쿠키 및 행태정보 수집
             </h2>
-            <p className="mt-2 leading-relaxed font-medium text-[#D6FDE5]">
+            <p className="mt-2 leading-relaxed font-medium text-green-light">
               쿠키 사용
             </p>
             <p className="mt-2 leading-relaxed">
-              <strong className="text-[#D6FDE5]">사용 목적:</strong> 로그인
+              <strong className="text-green-light">사용 목적:</strong> 로그인
               세션 유지
             </p>
             <p className="mt-2 leading-relaxed">
-              <strong className="text-[#D6FDE5]">거부 방법:</strong>
+              <strong className="text-green-light">거부 방법:</strong>
             </p>
             <ul className="mt-2 list-disc space-y-2 pl-5">
               <li>
@@ -133,24 +130,24 @@ export default function PrivacyPolicyModal({
           </section>
 
           <section className="mt-6">
-            <h2 className="text-bodyMd font-semibold text-[#D6FDE5]">
+            <h2 className="text-bodyMd font-semibold text-green-light">
               정보주체의 권리·의무 및 행사방법
             </h2>
             <p className="mt-2 leading-relaxed">
-              <strong className="text-[#D6FDE5]">권리 행사 방법:</strong>{" "}
+              <strong className="text-green-light">권리 행사 방법:</strong>{" "}
               website
             </p>
           </section>
 
           <section className="mt-6">
-            <h2 className="text-bodyMd font-semibold text-[#D6FDE5]">
+            <h2 className="text-bodyMd font-semibold text-green-light">
               개인정보 처리방침의 변경
             </h2>
             <p className="mt-2 leading-relaxed">
               이 개인정보 처리방침은 2026-06-28부터 적용됩니다.
             </p>
             <p className="mt-2 leading-relaxed">
-              <strong className="text-[#D6FDE5]">변경 고지 방법:</strong>{" "}
+              <strong className="text-green-light">변경 고지 방법:</strong>{" "}
               홈페이지 공지사항 게시
             </p>
           </section>

--- a/frontend/src/components/Modal/ModalTitle.tsx
+++ b/frontend/src/components/Modal/ModalTitle.tsx
@@ -1,18 +1,38 @@
+import type { ReactNode } from "react";
+
 type ModalTitleProps = {
   size?: "sm" | "lg";
   className?: string;
+  children?: ReactNode;
 };
 
-export function ModalTitle({ size = "sm", className = "" }: ModalTitleProps) {
+export function ModalTitle({
+  size = "sm",
+  className = "",
+  children,
+}: ModalTitleProps) {
   const sizeClasses = {
     sm: "text-2xl",
     lg: "mt-4 text-4xl",
   };
 
+  const brandClasses = `font-extrabold tracking-wide text-[#82C397] ${sizeClasses[size]} ${className}`;
+
+  if (children) {
+    return (
+      <>
+        <p aria-hidden="true" className={brandClasses}>
+          GRIT
+        </p>
+        <h2 id="modal-title" className="mt-2 text-sm font-medium text-green-light">
+          {children}
+        </h2>
+      </>
+    );
+  }
+
   return (
-    <h1
-      className={`font-extrabold tracking-wide text-[#82C397] ${sizeClasses[size]} ${className}`}
-    >
+    <h1 id="modal-title" className={brandClasses}>
       GRIT
     </h1>
   );

--- a/frontend/src/components/Modal/index.tsx
+++ b/frontend/src/components/Modal/index.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, useContext, useEffect, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { ModalOverlay } from "./ModalOverlay";
 import { ModalHeader } from "./ModalHeader";
@@ -31,6 +31,16 @@ type ModalProps = {
 };
 
 function Modal({ isOpen, onClose, children }: ModalProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const originalStyle = window.getComputedStyle(document.body).overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = originalStyle;
+    };
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   return createPortal(
@@ -39,6 +49,7 @@ function Modal({ isOpen, onClose, children }: ModalProps) {
         className="fixed inset-0 z-[var(--z-modal)] flex items-center justify-center"
         role="dialog"
         aria-modal="true"
+        aria-labelledby="modal-title"
         onClick={(e) => e.stopPropagation()}
       >
         {children}

--- a/frontend/src/components/Modal/index.tsx
+++ b/frontend/src/components/Modal/index.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { ModalOverlay } from "./ModalOverlay";
 import { ModalHeader } from "./ModalHeader";
 import { ModalBody } from "./ModalBody";
@@ -31,16 +32,19 @@ type ModalProps = {
 
 function Modal({ isOpen, onClose, children }: ModalProps) {
   if (!isOpen) return null;
-  return (
+
+  return createPortal(
     <ModalContext.Provider value={{ isOpen, onClose }}>
       <div
-        className="fixed inset-0 z-50 flex items-center justify-center"
+        className="fixed inset-0 z-[var(--z-modal)] flex items-center justify-center"
         role="dialog"
+        aria-modal="true"
         onClick={(e) => e.stopPropagation()}
       >
         {children}
       </div>
-    </ModalContext.Provider>
+    </ModalContext.Provider>,
+    document.body
   );
 }
 

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -7,6 +7,7 @@ import Achievement from "@/pages/Home/components/AchievementCard";
 import ProfileCard from "@/pages/Home/components/ProfileCard";
 import LeftSidebar from "@/pages/Home/components/LeftSidebar";
 import FriendManageModal from "@/pages/Home/components/Modals/FriendManageModal";
+import Footer from "@/components/Footer/Footer";
 
 type HomeLocationState = {
   openProfileSetupModal: boolean;
@@ -22,17 +23,17 @@ const HomePage = () => {
 
   return (
     <SmallViewportNotice>
-      <div className="flex flex-col pt-[65px] w-full h-auto bg-gray-darkest">
+      <div className="flex h-screen w-full flex-col overflow-hidden bg-gray-darkest pt-[65px]">
         <Header variant="dark" alwaysVisible />
-        <div className="flex h-screen overflow-hidden overscroll-contain">
+        <div className="flex min-h-0 flex-1 overflow-hidden">
           <aside className="w-17 shrink-0 bg-[#2E323A] py-5">
-            <div className="overflow-y-auto h-full">
+            <div className="h-full overflow-y-auto">
               <LeftSidebar
                 onOpenFriendManage={() => setIsFriendManageOpen(true)}
               />
             </div>
           </aside>
-          <div className="flex-1 overflow-y-auto overscroll-contain">
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
             <div className="mx-auto w-full max-w-[1180px] px-16 pb-16">
               <div className="mt-18 flex flex-col-reverse lg:flex-row items-center justify-center gap-8">
                 <Achievement />
@@ -45,12 +46,13 @@ const HomePage = () => {
                 <GroupSection />
               </div>
             </div>
+            <Footer variant="dark" />
           </div>
-          <FriendManageModal
-            open={isFriendManageOpen}
-            onClose={() => setIsFriendManageOpen(false)}
-          />
         </div>
+        <FriendManageModal
+          open={isFriendManageOpen}
+          onClose={() => setIsFriendManageOpen(false)}
+        />
       </div>
     </SmallViewportNotice>
   );

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -33,7 +33,7 @@ const HomePage = () => {
               />
             </div>
           </aside>
-          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+          <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain">
             <div className="mx-auto w-full max-w-[1180px] px-16 pb-16">
               <div className="mt-18 flex flex-col-reverse lg:flex-row items-center justify-center gap-8">
                 <Achievement />
@@ -46,7 +46,9 @@ const HomePage = () => {
                 <GroupSection />
               </div>
             </div>
-            <Footer variant="dark" />
+            <div className="mt-auto">
+              <Footer variant="dark" />
+            </div>
           </div>
         </div>
         <FriendManageModal

--- a/frontend/src/pages/Landing/components/IntroductionSection/IntroductionSection.tsx
+++ b/frontend/src/pages/Landing/components/IntroductionSection/IntroductionSection.tsx
@@ -1,4 +1,5 @@
 import type { RefObject } from "react";
+import Footer from "@/components/Footer/Footer";
 import IntroductionCard from "@/pages/Landing/components/IntroductionSection/IntroductionCard";
 
 type IntroductionSectionProps = {
@@ -40,12 +41,15 @@ export default function IntroductionSection({
         ref={(sec) => {
           sectionsRef.current[startIndex + 2] = sec;
         }}
-        className="h-screen"
+        className="relative h-screen"
       >
         <IntroductionCard
           functionName="투두리스트 관리"
           functionDescription="오늘 해야 할 일을 정리하고 끝까지 완주"
         />
+        <div className="absolute inset-x-0 bottom-0 z-10">
+          <Footer variant="light" />
+        </div>
       </section>
     </>
   );

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -15,4 +15,5 @@
   --color-tomato: #a43f3d;
 
   --z-header: 1000;
+  --z-modal: 1100;
 }


### PR DESCRIPTION
# 변경점 👍
- 홈·랜딩에 공통 `Footer` 컴포넌트 추가 (dark/light variant)
- 개인정보처리방침 클릭 시 `PrivacyPolicyModal`로 내용 표시
- 홈 스크롤 레이아웃 수정으로 푸터까지 스크롤 가능
- 랜딩 마지막 소개 섹션 하단에 푸터 오버레이 배치 (카드 위치 유지)
- 모달 `createPortal` + `--z-modal` 적용으로 헤더까지 오버레이 어둡게 처리