### PR TITLE
feat: 그룹 멤버 목록 API에 프로필 imageUrl 추가

### DIFF
--- a/backend/grit/src/main/java/grit/domain/group/GroupController.java
+++ b/backend/grit/src/main/java/grit/domain/group/GroupController.java
@@ -110,7 +110,8 @@ public class GroupController {
                 .map(member -> new GroupMemberResponseDto(
                         member.getId(),
                         member.getNickname(),
-                        member.getId().equals(memberPrincipal.id())
+                        member.getId().equals(memberPrincipal.id()),
+                        s3Service.resolveUrl(S3Directory.PROFILE_IMAGES, member.getImageName())
                 ))
                 .toList();
         return ResponseEntity.ok(response);

--- a/backend/grit/src/main/java/grit/domain/group/dto/GroupMemberResponseDto.java
+++ b/backend/grit/src/main/java/grit/domain/group/dto/GroupMemberResponseDto.java
@@ -8,6 +8,8 @@ public record GroupMemberResponseDto(
         @Schema(description = "회원 닉네임", example = "이유민")
         String nickname,
         @Schema(description = "요청자 본인 여부", example = "true")
-        boolean me
+        boolean me,
+        @Schema(description = "프로필 이미지 URL", example = "https://grit-s3.ap-northeast-2.amazonaws.com/profile-images/uuid", nullable = true)
+        String imageUrl
 ) {
 }


### PR DESCRIPTION
# 변경점 👍
- 그룹 멤버 목록 API 응답에 `imageUrl` 필드 추가
- 멤버별 프로필 이미지 S3 URL 변환 로직 적용