### PR TITLE
feat: 뽀모도로 트랜잭션 커밋 추적 추가

### DIFF
--- a/backend/grit/src/main/java/grit/domain/group/GroupController.java
+++ b/backend/grit/src/main/java/grit/domain/group/GroupController.java
@@ -110,7 +110,8 @@ public class GroupController {
                 .map(member -> new GroupMemberResponseDto(
                         member.getId(),
                         member.getNickname(),
-                        member.getId().equals(memberPrincipal.id())
+                        member.getId().equals(memberPrincipal.id()),
+                        s3Service.resolveUrl(S3Directory.PROFILE_IMAGES, member.getImageName())
                 ))
                 .toList();
         return ResponseEntity.ok(response);

--- a/backend/grit/src/main/java/grit/domain/group/dto/GroupMemberResponseDto.java
+++ b/backend/grit/src/main/java/grit/domain/group/dto/GroupMemberResponseDto.java
@@ -8,6 +8,8 @@ public record GroupMemberResponseDto(
         @Schema(description = "회원 닉네임", example = "이유민")
         String nickname,
         @Schema(description = "요청자 본인 여부", example = "true")
-        boolean me
+        boolean me,
+        @Schema(description = "프로필 이미지 URL", example = "https://grit-s3.ap-northeast-2.amazonaws.com/profile-images/uuid", nullable = true)
+        String imageUrl
 ) {
 }

--- a/backend/grit/src/main/java/grit/domain/group/livekit/pomodoro/service/PomodoroService.java
+++ b/backend/grit/src/main/java/grit/domain/group/livekit/pomodoro/service/PomodoroService.java
@@ -8,13 +8,15 @@ import grit.domain.group.livekit.service.LiveKitService;
 import grit.domain.member.entity.Member;
 import grit.global.exception.AccessDeniedException;
 import grit.global.exception.EntityNotFoundException;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +26,7 @@ public class PomodoroService {
     private final PomodoroRepository pomodoroRepository;
     private final LiveKitService liveKitService;
     private final Clock clock;
+    private final ObservationRegistry observationRegistry;
 
     @Transactional(readOnly = true)
     public Pomodoro findCurrent(Member member, String groupCode) {
@@ -48,7 +51,7 @@ public class PomodoroService {
         pomodoro.start(Instant.now(clock), focusMinutes, totalRounds);
 
         Pomodoro savedPomodoro = pomodoroRepository.save(pomodoro);
-        sendPomodoroSyncAfterCommit(member, group, savedPomodoro);
+        sendPomodoroSyncAfterCommit("start", member, group, savedPomodoro);
 
         return savedPomodoro;
     }
@@ -61,7 +64,7 @@ public class PomodoroService {
         Pomodoro pomodoro = findByGroup(group);
         pomodoro.pause(Instant.now(clock));
         Pomodoro savedPomodoro = pomodoroRepository.save(pomodoro);
-        sendPomodoroSyncAfterCommit(member, group, savedPomodoro);
+        sendPomodoroSyncAfterCommit("pause", member, group, savedPomodoro);
 
         return savedPomodoro;
     }
@@ -74,7 +77,7 @@ public class PomodoroService {
         Pomodoro pomodoro = findByGroup(group);
         pomodoro.resume(Instant.now(clock));
         Pomodoro savedPomodoro = pomodoroRepository.save(pomodoro);
-        sendPomodoroSyncAfterCommit(member, group, savedPomodoro);
+        sendPomodoroSyncAfterCommit("resume", member, group, savedPomodoro);
 
         return savedPomodoro;
     }
@@ -87,7 +90,7 @@ public class PomodoroService {
         Pomodoro pomodoro = findByGroup(group);
         pomodoro.stop();
         Pomodoro savedPomodoro = pomodoroRepository.save(pomodoro);
-        sendPomodoroSyncAfterCommit(member, group, savedPomodoro);
+        sendPomodoroSyncAfterCommit("stop", member, group, savedPomodoro);
 
         return savedPomodoro;
     }
@@ -97,16 +100,45 @@ public class PomodoroService {
                 .orElseThrow(() -> new EntityNotFoundException("진행 중인 뽀모도로가 없습니다."));
     }
 
-    private void sendPomodoroSyncAfterCommit(Member member, Group group, Pomodoro pomodoro) {
+    private void sendPomodoroSyncAfterCommit(String operation, Member member, Group group, Pomodoro pomodoro) {
         if (!TransactionSynchronizationManager.isSynchronizationActive()) {
             liveKitService.sendPomodoroSync(member, group, pomodoro);
             return;
         }
 
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            private Observation commitObservation;
+            private Observation.Scope commitScope;
+
+            @Override
+            public void beforeCompletion() {
+                commitObservation = Observation.createNotStarted("pomodoro.tx.commit", observationRegistry)
+                        .contextualName("Pomodoro transaction commit")
+                        .lowCardinalityKeyValue("pomodoro.operation", operation)
+                        .start();
+                commitScope = commitObservation.openScope();
+            }
+
             @Override
             public void afterCommit() {
+                stopCommitObservation();
                 liveKitService.sendPomodoroSync(member, group, pomodoro);
+            }
+
+            @Override
+            public void afterCompletion(int status) {
+                stopCommitObservation();
+            }
+
+            private void stopCommitObservation() {
+                if (commitObservation != null) {
+                    if (commitScope != null) {
+                        commitScope.close();
+                    }
+                    commitObservation.stop();
+                    commitScope = null;
+                    commitObservation = null;
+                }
             }
         });
     }

--- a/backend/grit/src/main/java/grit/domain/group/livekit/service/LiveKitService.java
+++ b/backend/grit/src/main/java/grit/domain/group/livekit/service/LiveKitService.java
@@ -13,7 +13,10 @@ import io.livekit.server.CanSubscribe;
 import io.livekit.server.RoomJoin;
 import io.livekit.server.RoomName;
 import io.livekit.server.RoomServiceClient;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
 import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -22,6 +25,7 @@ import livekit.LivekitModels.DataPacket.Kind;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import retrofit2.Response;
 import tools.jackson.databind.ObjectMapper;
 
 @Service
@@ -40,6 +44,7 @@ public class LiveKitService {
     private final GroupService groupService;
     private final ObjectMapper objectMapper;
     private final Clock clock;
+    private final ObservationRegistry observationRegistry;
     private RoomServiceClient client;
 
     @PostConstruct
@@ -68,6 +73,7 @@ public class LiveKitService {
         Group group = groupService.findGroupByCode(groupCode);
         checkPermission(member, group);
         sendData(roomName(group.getCode()),
+                "reaction",
                 Map.of(
                         "type", "reaction",
                         "emoji", emoji.name(),
@@ -91,6 +97,7 @@ public class LiveKitService {
         timer.put("totalRounds", pomodoro.getTotalRounds());
 
         sendData(roomName(group.getCode()),
+                "pomodoro.sync",
                 Map.of(
                         "type", "pomodoro.sync",
                         "timer", timer,
@@ -98,12 +105,30 @@ public class LiveKitService {
                 ), Kind.RELIABLE);
     }
 
-    private void sendData(String roomName, Object payload, Kind kind) {
-        try {
+    private void sendData(String roomName, String messageType, Object payload, Kind kind) {
+        Observation observation = Observation.createNotStarted("livekit.send_data", observationRegistry)
+                .contextualName("LiveKit send data")
+                .lowCardinalityKeyValue("livekit.message_type", messageType)
+                .lowCardinalityKeyValue("livekit.kind", kind.name())
+                .highCardinalityKeyValue("livekit.room", roomName)
+                .start();
+
+        try (Observation.Scope ignored = observation.openScope()) {
             String json = objectMapper.writeValueAsString(payload);
-            client.sendData(roomName, json.getBytes(), kind).execute();
+            byte[] payloadBytes = json.getBytes(StandardCharsets.UTF_8);
+            observation.highCardinalityKeyValue("livekit.payload.bytes", String.valueOf(payloadBytes.length));
+            Response<Void> response = client.sendData(roomName, payloadBytes, kind).execute();
+            if (!response.isSuccessful()) {
+                throw new RuntimeException("LiveKit send data failed. status="
+                        + response.code()
+                        + ", message="
+                        + response.message());
+            }
         } catch (Exception e) {
+            observation.error(e);
             throw new RuntimeException("Failed to send data to LiveKit", e);
+        } finally {
+            observation.stop();
         }
     }
 


### PR DESCRIPTION
# 변경점 👍
- 뽀모도로 조작 API의 트랜잭션 커밋 구간에 `pomodoro.tx.commit` Observation 추가
- `start`, `pause`, `resume`, `stop` 작업 구분을 위한 `pomodoro.operation` tag 추가
- 커밋 이후 LiveKit sync 전송과 DB 커밋 지연 구간을 분리해서 확인 가능하도록 처리
