### PR TITLE
feat: 공부 타이머 API 연동

### DIFF
--- a/frontend/src/apis/constants/endpoints.ts
+++ b/frontend/src/apis/constants/endpoints.ts
@@ -12,6 +12,9 @@ export const ENDPOINTS = {
     PROFILE: "/api/members/me/profile",
     NICKNAME_CHECK: "/api/members/nickname-availability",
     IMAGE_UPLOAD: `/api/members/me/profile-image/upload-url`,
+    STUDY_TIME: "/api/members/me/study-time",
+    STUDY_TIME_RESUME: "/api/members/me/study-time/resume",
+    STUDY_TIME_PAUSE: "/api/members/me/study-time/pause",
   },
   GROUP: {
     CREATE: "/api/groups",

--- a/frontend/src/apis/constants/queryKeys.ts
+++ b/frontend/src/apis/constants/queryKeys.ts
@@ -2,6 +2,9 @@ export const QUERY_KEYS = {
   member: {
     me: ["member", "me"] as const,
   },
+  studyTime: {
+    me: ["studyTime", "me"] as const,
+  },
   groups: {
     all: ["groups"] as const,
     my: ["groups", "my"] as const,

--- a/frontend/src/apis/domains/studyTime/api.ts
+++ b/frontend/src/apis/domains/studyTime/api.ts
@@ -1,0 +1,26 @@
+import apiClient from "@/apis/client/apiClient";
+import { ENDPOINTS } from "@/apis/constants/endpoints";
+import type { MemberStudyTimeResponse } from "@/apis/domains/studyTime/type";
+
+export const studyTimeApi = {
+  get: async (): Promise<MemberStudyTimeResponse> => {
+    const response = await apiClient.get<MemberStudyTimeResponse>(
+      ENDPOINTS.MY.STUDY_TIME,
+    );
+    return response.data;
+  },
+
+  resume: async (): Promise<MemberStudyTimeResponse> => {
+    const response = await apiClient.post<MemberStudyTimeResponse>(
+      ENDPOINTS.MY.STUDY_TIME_RESUME,
+    );
+    return response.data;
+  },
+
+  pause: async (): Promise<MemberStudyTimeResponse> => {
+    const response = await apiClient.post<MemberStudyTimeResponse>(
+      ENDPOINTS.MY.STUDY_TIME_PAUSE,
+    );
+    return response.data;
+  },
+} as const;

--- a/frontend/src/apis/domains/studyTime/type.ts
+++ b/frontend/src/apis/domains/studyTime/type.ts
@@ -1,0 +1,8 @@
+export type MemberStudyTimeResponse = {
+  weekStartDate: string;
+  weeklyStudyTimeGoalSeconds: number | null;
+  currentWeekStudyTimeSeconds: number;
+  running: boolean;
+  serverNow: string;
+  lastStartedAt: string | null;
+};

--- a/frontend/src/hooks/usePauseStudyTime.ts
+++ b/frontend/src/hooks/usePauseStudyTime.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { studyTimeApi } from "@/apis/domains/studyTime/api";
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
+
+export function usePauseStudyTime() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ["studyTime", "pause"],
+    mutationFn: studyTimeApi.pause,
+    onError: (error) => {
+      console.error("공부 타이머 일시정지 실패", error);
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.studyTime.me });
+    },
+  });
+}

--- a/frontend/src/hooks/useResumeStudyTime.ts
+++ b/frontend/src/hooks/useResumeStudyTime.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { studyTimeApi } from "@/apis/domains/studyTime/api";
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
+
+export function useResumeStudyTime() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ["studyTime", "resume"],
+    mutationFn: studyTimeApi.resume,
+    onError: (error) => {
+      console.error("공부 타이머 재개 실패", error);
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.studyTime.me });
+    },
+  });
+}

--- a/frontend/src/hooks/useStudyTime.ts
+++ b/frontend/src/hooks/useStudyTime.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { studyTimeApi } from "@/apis/domains/studyTime/api";
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
+
+type UseStudyTimeOptions = {
+  enabled?: boolean;
+};
+
+export function useStudyTime({ enabled = true }: UseStudyTimeOptions = {}) {
+  return useQuery({
+    queryKey: QUERY_KEYS.studyTime.me,
+    queryFn: studyTimeApi.get,
+    enabled,
+    staleTime: 0,
+    refetchOnMount: "always",
+  });
+}

--- a/frontend/src/pages/Home/components/GroupSection/GroupCard.tsx
+++ b/frontend/src/pages/Home/components/GroupSection/GroupCard.tsx
@@ -26,6 +26,7 @@ export default function GroupCard({
     void queryClient.prefetchQuery({
       queryKey: QUERY_KEYS.studyTime.me,
       queryFn: studyTimeApi.get,
+      staleTime: 5000,
     });
     navigate(`/room/${groupCode}`);
   };
@@ -34,6 +35,7 @@ export default function GroupCard({
     void queryClient.prefetchQuery({
       queryKey: QUERY_KEYS.studyTime.me,
       queryFn: studyTimeApi.get,
+      staleTime: 5000,
     });
   };
 

--- a/frontend/src/pages/Home/components/GroupSection/GroupCard.tsx
+++ b/frontend/src/pages/Home/components/GroupSection/GroupCard.tsx
@@ -1,10 +1,13 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import { Pencil } from "lucide-react";
 import LiveBadge from "./LiveBadge";
 import GroupCodeBadge from "./GroupCodeBadge";
 import GroupSettingsModal from "@/pages/Home/components/Modals/GroupSettingsModal";
 import type { Group } from "@/apis/domains/group/type";
+import { studyTimeApi } from "@/apis/domains/studyTime/api";
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
 
 type GroupCardProps = Group;
 
@@ -17,14 +20,28 @@ export default function GroupCard({
   liveParticipantCount,
 }: GroupCardProps) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const handleGoToRoom = () => {
+    void queryClient.prefetchQuery({
+      queryKey: QUERY_KEYS.studyTime.me,
+      queryFn: studyTimeApi.get,
+    });
     navigate(`/room/${groupCode}`);
+  };
+
+  const prefetchStudyTime = () => {
+    void queryClient.prefetchQuery({
+      queryKey: QUERY_KEYS.studyTime.me,
+      queryFn: studyTimeApi.get,
+    });
   };
 
   return (
     <div
       onClick={handleGoToRoom}
+      onMouseEnter={prefetchStudyTime}
+      onFocus={prefetchStudyTime}
       className="w-full h-fit bg-gray-dark rounded-2xl shadow-xl/20"
     >
       <div className="group/card flex flex-col overflow-hidden relative aspect-square rounded-2xl w-full bg-gray-semidark">

--- a/frontend/src/pages/Home/components/ProfileCard.tsx
+++ b/frontend/src/pages/Home/components/ProfileCard.tsx
@@ -3,8 +3,13 @@ import { Settings, MessageCircle } from "lucide-react";
 import Avatar from "@/components/Avatar";
 import SettingsModal from "@/pages/Home/components/Modals/ProfileSettingsModal";
 import { useMember } from "@/hooks/useMember";
+import { useStudyTime } from "@/hooks/useStudyTime";
 import { formatDisplayDate, formatDDayLabel } from "@/utils/date";
 import { formatStudyGoalDisplay } from "@/utils/studyGoalTime";
+import {
+  getDisplayedStudySeconds,
+  getStudyTimeProgressPercent,
+} from "@/utils/studyTime";
 
 interface ProfileCardProps {
   initialSettingsOpen: boolean;
@@ -24,6 +29,7 @@ const ProfileCard = ({
     isError,
     refetch,
   } = useMember();
+  const { data: studyTime } = useStudyTime();
 
   useEffect(() => {
     if (initialSettingsOpen && oauthFirstTimeUser) {
@@ -38,6 +44,10 @@ const ProfileCard = ({
   const displayName = member?.nickname?.trim() || member?.email || "—";
   const motivation = member?.introduction?.trim() || "소개를 입력해주세요";
   const goalTimeLabel = formatStudyGoalDisplay(member?.weeklyStudyTimeGoal);
+  const studyProgressPercent = getStudyTimeProgressPercent(
+    getDisplayedStudySeconds(studyTime),
+    studyTime?.weeklyStudyTimeGoalSeconds,
+  );
 
   return (
     <div className="w-full lg:w-1/2 h-64 bg-green-dark rounded-2xl p-6">
@@ -113,8 +123,7 @@ const ProfileCard = ({
         <div className="w-full h-4 bg-gray-dark rounded-full overflow-hidden">
           <div
             className="h-full bg-green-normal rounded-full transition-all duration-300"
-            style={{ width: "0%" }}
-            title="실시간 공부 시간 연동 전"
+            style={{ width: `${studyProgressPercent}%` }}
           />
         </div>
       </div>

--- a/frontend/src/pages/Room/components/TopBar/TopBar.tsx
+++ b/frontend/src/pages/Room/components/TopBar/TopBar.tsx
@@ -1,39 +1,40 @@
 import CustomBtn from "@/pages/Room/components/CustomBtn";
-import { useState, useEffect } from "react";
-import { Play, ListChecks, Settings } from "lucide-react";
+import { Pause, Play, ListChecks, Settings } from "lucide-react";
 import { Link } from "react-router-dom";
 import { PATHS } from "@/routes/path";
 import { useMember } from "@/hooks/useMember";
 import { getDDayDisplayParts } from "@/utils/date";
 import { formatStudyGoalAsClock } from "@/utils/studyGoalTime";
-
-function formatTime(seconds: number) {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = seconds % 60;
-  return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
-}
+import { formatStudySecondsAsClock } from "@/utils/studyTime";
 
 type TopBarProps = {
   isTodoOpen?: boolean;
   onToggleTodo?: () => void;
+  displayedStudySeconds?: number;
+  isStudyTimerRunning?: boolean;
+  isStudyTimerPending?: boolean;
+  onToggleStudyTimer?: () => void;
+  weeklyStudyTimeGoalSeconds?: number | null;
 };
 
-export default function TopBar({ isTodoOpen = false, onToggleTodo }: TopBarProps) {
+export default function TopBar({
+  isTodoOpen = false,
+  onToggleTodo,
+  displayedStudySeconds = 0,
+  isStudyTimerRunning = false,
+  isStudyTimerPending = false,
+  onToggleStudyTimer,
+  weeklyStudyTimeGoalSeconds,
+}: TopBarProps) {
   const { data: member } = useMember();
 
-  const { sign: dDaySign, days: dDayDays } = getDDayDisplayParts(member?.dDayDate);
-  const totalTime = formatStudyGoalAsClock(member?.weeklyStudyTimeGoal);
-
-  const [elapsedSeconds, setElapsedSeconds] = useState(0);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setElapsedSeconds((prev) => prev + 1);
-    }, 1000);
-
-    return () => clearInterval(interval);
-  }, []);
+  const { sign: dDaySign, days: dDayDays } = getDDayDisplayParts(
+    member?.dDayDate,
+  );
+  const totalTime =
+    weeklyStudyTimeGoalSeconds != null
+      ? formatStudySecondsAsClock(weeklyStudyTimeGoalSeconds)
+      : formatStudyGoalAsClock(member?.weeklyStudyTimeGoal);
 
   return (
     <div className="flex items-center justify-between w-full h-20 gap-4 px-6">
@@ -53,10 +54,25 @@ export default function TopBar({ isTodoOpen = false, onToggleTodo }: TopBarProps
           </div>
 
           <div className="flex items-center gap-1.5">
-            <Play size={15} className="relative top-[2px]" />
+            <button
+              type="button"
+              onClick={onToggleStudyTimer}
+              disabled={!onToggleStudyTimer}
+              aria-busy={isStudyTimerPending}
+              aria-label={
+                isStudyTimerRunning ? "공부 타이머 일시정지" : "공부 타이머 시작"
+              }
+              className="cursor-pointer disabled:cursor-not-allowed"
+            >
+              {isStudyTimerRunning ? (
+                <Pause size={15} className="relative top-[2px]" />
+              ) : (
+                <Play size={15} className="relative top-[2px]" />
+              )}
+            </button>
             <div className="flex items-baseline gap-1 leading-none relative top-[1px]">
               <div className="ml-1 font-semibold text-h3">
-                {formatTime(elapsedSeconds)}
+                {formatStudySecondsAsClock(displayedStudySeconds)}
               </div>
               <div className="text-bodyMd">/ {totalTime}</div>
             </div>

--- a/frontend/src/pages/Room/hooks/index.ts
+++ b/frontend/src/pages/Room/hooks/index.ts
@@ -3,3 +3,4 @@ export { useRoomLiveKitData } from "./useRoomLiveKitData";
 export { useRoomParticipants } from "./useRoomParticipants";
 export { useRoomPomodoro } from "./useRoomPomodoro";
 export { useRoomReactions } from "./useRoomReactions";
+export { useRoomStudyTime } from "./useRoomStudyTime";

--- a/frontend/src/pages/Room/hooks/useRoomLiveKitData.ts
+++ b/frontend/src/pages/Room/hooks/useRoomLiveKitData.ts
@@ -1,10 +1,14 @@
 import { useCallback } from "react";
 import { useRoomPomodoro } from "@/pages/Room/hooks/useRoomPomodoro";
 import { useRoomReactions } from "@/pages/Room/hooks/useRoomReactions";
+import { useRoomStudyTime } from "@/pages/Room/hooks/useRoomStudyTime";
 
 export function useRoomLiveKitData(groupCode: string | undefined) {
   const pomodoro = useRoomPomodoro(groupCode);
   const reactions = useRoomReactions(groupCode);
+  const studyTime = useRoomStudyTime({
+    pomodoroStatus: pomodoro.pomodoroStatus,
+  });
 
   const handleDataReceived = useCallback(
     (payload: Uint8Array) => {
@@ -23,6 +27,7 @@ export function useRoomLiveKitData(groupCode: string | undefined) {
   return {
     pomodoro,
     reactions,
+    studyTime,
     handleDataReceived,
   };
 }

--- a/frontend/src/pages/Room/hooks/useRoomStudyTime.ts
+++ b/frontend/src/pages/Room/hooks/useRoomStudyTime.ts
@@ -13,6 +13,28 @@ import {
 } from "@/utils/pomodoroStudySync";
 import { getDisplayedStudySeconds } from "@/utils/studyTime";
 
+const STUDY_TIMER_KEEP_RUNNING_KEY = "grit:studyTimerKeepRunning";
+
+function readKeepRunningIntent(): boolean {
+  try {
+    return sessionStorage.getItem(STUDY_TIMER_KEEP_RUNNING_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeKeepRunningIntent(keepRunning: boolean) {
+  try {
+    if (keepRunning) {
+      sessionStorage.setItem(STUDY_TIMER_KEEP_RUNNING_KEY, "1");
+    } else {
+      sessionStorage.removeItem(STUDY_TIMER_KEEP_RUNNING_KEY);
+    }
+  } catch {
+    // sessionStorage 불가 환경은 무시
+  }
+}
+
 function buildOptimisticRunning(
   prev: MemberStudyTimeResponse | undefined,
   displayedSeconds: number,
@@ -171,6 +193,7 @@ export function useRoomStudyTime({ pomodoroStatus }: UseRoomStudyTimeOptions) {
       );
       if (current?.running === running) return;
 
+      writeKeepRunningIntent(running);
       desiredRunningRef.current = running;
       applyOptimistic(
         running
@@ -199,32 +222,44 @@ export function useRoomStudyTime({ pomodoroStatus }: UseRoomStudyTimeOptions) {
   }, [queryClient, setDesiredRunning]);
 
   useEffect(() => {
-    if (!studyTime || !pomodoroStatus) return;
+    // studyTime + pomodoro 모두 준비된 뒤 한 번만 처리
+    if (!studyTime || !pomodoroStatus || didInitialSyncRef.current) return;
+    didInitialSyncRef.current = true;
+
+    const phase = getPomodoroStudyPhase(pomodoroStatus);
+    prevPomodoroPhaseRef.current = phase;
+
+    if (studyTime.running) {
+      writeKeepRunningIntent(true);
+      return;
+    }
+
+    // 수동으로 끈 상태는 유지. 재생 중이었는데 방 이탈 등으로 멈춘 경우만 복구.
+    if (!readKeepRunningIntent()) return;
+    if (phase === "break" || phase === "paused") return;
+
+    syncResume();
+  }, [pomodoroStatus, studyTime, syncResume]);
+
+  useEffect(() => {
+    if (!pomodoroStatus) return;
 
     const phase = getPomodoroStudyPhase(pomodoroStatus);
     const prevPhase = prevPomodoroPhaseRef.current;
 
-    // 최초 로드(새로고침/재입장): 현재 국면에 한 번 맞춤
-    if (!didInitialSyncRef.current) {
-      didInitialSyncRef.current = true;
-      prevPomodoroPhaseRef.current = phase;
-      if (shouldStudyTimerRunForPhase(phase)) {
-        syncResume();
-      } else {
-        syncPause();
-      }
-      return;
-    }
-
+    // 초기 phase 기록은 위 effect에서 수행
+    if (prevPhase === null) return;
     if (prevPhase === phase) return;
+
     prevPomodoroPhaseRef.current = phase;
 
     if (shouldStudyTimerRunForPhase(phase)) {
       syncResume();
-    } else {
-      syncPause();
+      return;
     }
-  }, [pomodoroStatus, studyTime, syncPause, syncResume]);
+
+    syncPause();
+  }, [pomodoroStatus, syncPause, syncResume]);
 
   return {
     studyTime,

--- a/frontend/src/pages/Room/hooks/useRoomStudyTime.ts
+++ b/frontend/src/pages/Room/hooks/useRoomStudyTime.ts
@@ -31,7 +31,7 @@ function writeKeepRunningIntent(keepRunning: boolean) {
       sessionStorage.removeItem(STUDY_TIMER_KEEP_RUNNING_KEY);
     }
   } catch {
-    // sessionStorage 불가 환경은 무시
+    // ignore
   }
 }
 
@@ -65,6 +65,10 @@ function buildOptimisticPaused(
   };
 }
 
+function isPomodoroBlockingPhase(phase: PomodoroStudyPhase): boolean {
+  return phase === "break" || phase === "paused";
+}
+
 type UseRoomStudyTimeOptions = {
   pomodoroStatus: PomodoroStatusResponse | undefined;
 };
@@ -84,7 +88,10 @@ export function useRoomStudyTime({ pomodoroStatus }: UseRoomStudyTimeOptions) {
   const fetchedAtRef = useRef<number | undefined>(undefined);
   const displayedSecondsRef = useRef(0);
   const prevPomodoroPhaseRef = useRef<PomodoroStudyPhase | null>(null);
-  const didInitialSyncRef = useRef(false);
+  const didBindPomodoroPhaseRef = useRef(false);
+  const pomodoroStatusRef = useRef(pomodoroStatus);
+
+  pomodoroStatusRef.current = pomodoroStatus;
 
   useEffect(() => {
     if (dataUpdatedAt) {
@@ -221,25 +228,50 @@ export function useRoomStudyTime({ pomodoroStatus }: UseRoomStudyTimeOptions) {
     setDesiredRunning(!current?.running);
   }, [queryClient, setDesiredRunning]);
 
-  useEffect(() => {
-    // studyTime + pomodoro 모두 준비된 뒤 한 번만 처리
-    if (!studyTime || !pomodoroStatus || didInitialSyncRef.current) return;
-    didInitialSyncRef.current = true;
+  /** 재생 의도인데 서버/캐시가 멈춤이면 다시 재생 (탭 복귀·refetch 대응) */
+  const restoreKeepRunningIfNeeded = useCallback(() => {
+    if (!readKeepRunningIntent()) return;
 
-    const phase = getPomodoroStudyPhase(pomodoroStatus);
-    prevPomodoroPhaseRef.current = phase;
+    const phase = pomodoroStatusRef.current
+      ? getPomodoroStudyPhase(pomodoroStatusRef.current)
+      : "idle";
+    if (isPomodoroBlockingPhase(phase)) return;
+
+    const current = queryClient.getQueryData<MemberStudyTimeResponse>(
+      QUERY_KEYS.studyTime.me,
+    );
+    if (!current || current.running) return;
+
+    syncResume();
+  }, [queryClient, syncResume]);
+
+  useEffect(() => {
+    if (!studyTime) return;
 
     if (studyTime.running) {
       writeKeepRunningIntent(true);
       return;
     }
 
-    // 수동으로 끈 상태는 유지. 재생 중이었는데 방 이탈 등으로 멈춘 경우만 복구.
-    if (!readKeepRunningIntent()) return;
-    if (phase === "break" || phase === "paused") return;
+    restoreKeepRunningIfNeeded();
+  }, [studyTime, restoreKeepRunningIfNeeded]);
 
-    syncResume();
-  }, [pomodoroStatus, studyTime, syncResume]);
+  useEffect(() => {
+    const handleVisible = () => {
+      if (document.visibilityState !== "visible") return;
+
+      // 탭 복귀 시 최신 서버 상태 확인 + 재생 의도 복구
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.studyTime.me });
+      restoreKeepRunningIfNeeded();
+    };
+
+    document.addEventListener("visibilitychange", handleVisible);
+    window.addEventListener("focus", handleVisible);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisible);
+      window.removeEventListener("focus", handleVisible);
+    };
+  }, [queryClient, restoreKeepRunningIfNeeded]);
 
   useEffect(() => {
     if (!pomodoroStatus) return;
@@ -247,10 +279,13 @@ export function useRoomStudyTime({ pomodoroStatus }: UseRoomStudyTimeOptions) {
     const phase = getPomodoroStudyPhase(pomodoroStatus);
     const prevPhase = prevPomodoroPhaseRef.current;
 
-    // 초기 phase 기록은 위 effect에서 수행
-    if (prevPhase === null) return;
-    if (prevPhase === phase) return;
+    if (!didBindPomodoroPhaseRef.current) {
+      didBindPomodoroPhaseRef.current = true;
+      prevPomodoroPhaseRef.current = phase;
+      return;
+    }
 
+    if (prevPhase === null || prevPhase === phase) return;
     prevPomodoroPhaseRef.current = phase;
 
     if (shouldStudyTimerRunForPhase(phase)) {
@@ -258,6 +293,7 @@ export function useRoomStudyTime({ pomodoroStatus }: UseRoomStudyTimeOptions) {
       return;
     }
 
+    // break / paused / idle(정지) 전환만 타이머 pause
     syncPause();
   }, [pomodoroStatus, syncPause, syncResume]);
 

--- a/frontend/src/pages/Room/hooks/useRoomStudyTime.ts
+++ b/frontend/src/pages/Room/hooks/useRoomStudyTime.ts
@@ -19,7 +19,7 @@ function buildOptimisticRunning(
 ): MemberStudyTimeResponse {
   const nowIso = new Date().toISOString();
   return {
-    weekStartDate: prev?.weekStartDate ?? "",
+    weekStartDate: prev?.weekStartDate ?? nowIso.slice(0, 10),
     weeklyStudyTimeGoalSeconds: prev?.weeklyStudyTimeGoalSeconds ?? null,
     currentWeekStudyTimeSeconds: displayedSeconds,
     running: true,
@@ -34,7 +34,7 @@ function buildOptimisticPaused(
 ): MemberStudyTimeResponse {
   const nowIso = new Date().toISOString();
   return {
-    weekStartDate: prev?.weekStartDate ?? "",
+    weekStartDate: prev?.weekStartDate ?? nowIso.slice(0, 10),
     weeklyStudyTimeGoalSeconds: prev?.weeklyStudyTimeGoalSeconds ?? null,
     currentWeekStudyTimeSeconds: displayedSeconds,
     running: false,
@@ -176,11 +176,12 @@ export function useRoomStudyTime({ pomodoroStatus }: UseRoomStudyTimeOptions) {
 
   const setDesiredRunning = useCallback(
     (running: boolean) => {
-      desiredRunningRef.current = running;
-
       const current = queryClient.getQueryData<MemberStudyTimeResponse>(
         QUERY_KEYS.studyTime.me,
       );
+      if (current?.running === running) return;
+
+      desiredRunningRef.current = running;
       applyOptimistic(
         running
           ? buildOptimisticRunning(current, displayedSecondsRef.current)
@@ -209,17 +210,15 @@ export function useRoomStudyTime({ pomodoroStatus }: UseRoomStudyTimeOptions) {
 
   useEffect(() => {
     const reconcile = () => {
+      // studyTime·pomodoro 둘 다 준비된 뒤에만 동기화 (새로고침/재입장 포함)
+      if (!studyTime || !pomodoroStatus) return;
+
       const phase = getPomodoroStudyPhase(
         pomodoroStatus,
         Date.now(),
         pomodoroFetchedAtRef.current,
       );
       const prevPhase = prevPomodoroPhaseRef.current;
-
-      if (prevPhase === null) {
-        prevPomodoroPhaseRef.current = phase;
-        return;
-      }
 
       if (prevPhase === phase) return;
       prevPomodoroPhaseRef.current = phase;
@@ -234,7 +233,7 @@ export function useRoomStudyTime({ pomodoroStatus }: UseRoomStudyTimeOptions) {
     reconcile();
     const interval = window.setInterval(reconcile, 250);
     return () => window.clearInterval(interval);
-  }, [pomodoroStatus, syncPause, syncResume]);
+  }, [pomodoroStatus, syncPause, syncResume, studyTime]);
 
   return {
     studyTime,

--- a/frontend/src/pages/Room/hooks/useRoomStudyTime.ts
+++ b/frontend/src/pages/Room/hooks/useRoomStudyTime.ts
@@ -61,24 +61,14 @@ export function useRoomStudyTime({ pomodoroStatus }: UseRoomStudyTimeOptions) {
   const inflightRef = useRef(false);
   const fetchedAtRef = useRef<number | undefined>(undefined);
   const displayedSecondsRef = useRef(0);
-  const pomodoroFetchedAtRef = useRef<number>(Date.now());
   const prevPomodoroPhaseRef = useRef<PomodoroStudyPhase | null>(null);
+  const didInitialSyncRef = useRef(false);
 
   useEffect(() => {
     if (dataUpdatedAt) {
       fetchedAtRef.current = dataUpdatedAt;
     }
   }, [dataUpdatedAt]);
-
-  useEffect(() => {
-    pomodoroFetchedAtRef.current = Date.now();
-  }, [
-    pomodoroStatus?.status,
-    pomodoroStatus?.phase,
-    pomodoroStatus?.serverNow,
-    pomodoroStatus?.focusEndsAt,
-    pomodoroStatus?.breakEndsAt,
-  ]);
 
   const [displayedSeconds, setDisplayedSeconds] = useState(0);
 
@@ -209,31 +199,32 @@ export function useRoomStudyTime({ pomodoroStatus }: UseRoomStudyTimeOptions) {
   }, [queryClient, setDesiredRunning]);
 
   useEffect(() => {
-    const reconcile = () => {
-      // studyTime·pomodoro 둘 다 준비된 뒤에만 동기화 (새로고침/재입장 포함)
-      if (!studyTime || !pomodoroStatus) return;
+    if (!studyTime || !pomodoroStatus) return;
 
-      const phase = getPomodoroStudyPhase(
-        pomodoroStatus,
-        Date.now(),
-        pomodoroFetchedAtRef.current,
-      );
-      const prevPhase = prevPomodoroPhaseRef.current;
+    const phase = getPomodoroStudyPhase(pomodoroStatus);
+    const prevPhase = prevPomodoroPhaseRef.current;
 
-      if (prevPhase === phase) return;
+    // 최초 로드(새로고침/재입장): 현재 국면에 한 번 맞춤
+    if (!didInitialSyncRef.current) {
+      didInitialSyncRef.current = true;
       prevPomodoroPhaseRef.current = phase;
-
       if (shouldStudyTimerRunForPhase(phase)) {
         syncResume();
       } else {
         syncPause();
       }
-    };
+      return;
+    }
 
-    reconcile();
-    const interval = window.setInterval(reconcile, 250);
-    return () => window.clearInterval(interval);
-  }, [pomodoroStatus, syncPause, syncResume, studyTime]);
+    if (prevPhase === phase) return;
+    prevPomodoroPhaseRef.current = phase;
+
+    if (shouldStudyTimerRunForPhase(phase)) {
+      syncResume();
+    } else {
+      syncPause();
+    }
+  }, [pomodoroStatus, studyTime, syncPause, syncResume]);
 
   return {
     studyTime,

--- a/frontend/src/pages/Room/hooks/useRoomStudyTime.ts
+++ b/frontend/src/pages/Room/hooks/useRoomStudyTime.ts
@@ -1,0 +1,250 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { MemberStudyTimeResponse } from "@/apis/domains/studyTime/type";
+import type { PomodoroStatusResponse } from "@/apis/domains/pomodoro/type";
+import { QUERY_KEYS } from "@/apis/constants/queryKeys";
+import { useStudyTime } from "@/hooks/useStudyTime";
+import { usePauseStudyTime } from "@/hooks/usePauseStudyTime";
+import { useResumeStudyTime } from "@/hooks/useResumeStudyTime";
+import {
+  getPomodoroStudyPhase,
+  shouldStudyTimerRunForPhase,
+  type PomodoroStudyPhase,
+} from "@/utils/pomodoroStudySync";
+import { getDisplayedStudySeconds } from "@/utils/studyTime";
+
+function buildOptimisticRunning(
+  prev: MemberStudyTimeResponse | undefined,
+  displayedSeconds: number,
+): MemberStudyTimeResponse {
+  const nowIso = new Date().toISOString();
+  return {
+    weekStartDate: prev?.weekStartDate ?? "",
+    weeklyStudyTimeGoalSeconds: prev?.weeklyStudyTimeGoalSeconds ?? null,
+    currentWeekStudyTimeSeconds: displayedSeconds,
+    running: true,
+    serverNow: nowIso,
+    lastStartedAt: nowIso,
+  };
+}
+
+function buildOptimisticPaused(
+  prev: MemberStudyTimeResponse | undefined,
+  displayedSeconds: number,
+): MemberStudyTimeResponse {
+  const nowIso = new Date().toISOString();
+  return {
+    weekStartDate: prev?.weekStartDate ?? "",
+    weeklyStudyTimeGoalSeconds: prev?.weeklyStudyTimeGoalSeconds ?? null,
+    currentWeekStudyTimeSeconds: displayedSeconds,
+    running: false,
+    serverNow: nowIso,
+    lastStartedAt: null,
+  };
+}
+
+type UseRoomStudyTimeOptions = {
+  pomodoroStatus: PomodoroStatusResponse | undefined;
+};
+
+export function useRoomStudyTime({ pomodoroStatus }: UseRoomStudyTimeOptions) {
+  const queryClient = useQueryClient();
+  const { data: studyTime, dataUpdatedAt, isLoading, isFetching } =
+    useStudyTime();
+
+  const { mutateAsync: resumeStudyTimeAsync } = useResumeStudyTime();
+  const { mutateAsync: pauseStudyTimeAsync } = usePauseStudyTime();
+
+  const [isSyncing, setIsSyncing] = useState(false);
+
+  const desiredRunningRef = useRef<boolean | null>(null);
+  const inflightRef = useRef(false);
+  const fetchedAtRef = useRef<number | undefined>(undefined);
+  const displayedSecondsRef = useRef(0);
+  const pomodoroFetchedAtRef = useRef<number>(Date.now());
+  const prevPomodoroPhaseRef = useRef<PomodoroStudyPhase | null>(null);
+
+  useEffect(() => {
+    if (dataUpdatedAt) {
+      fetchedAtRef.current = dataUpdatedAt;
+    }
+  }, [dataUpdatedAt]);
+
+  useEffect(() => {
+    pomodoroFetchedAtRef.current = Date.now();
+  }, [
+    pomodoroStatus?.status,
+    pomodoroStatus?.phase,
+    pomodoroStatus?.serverNow,
+    pomodoroStatus?.focusEndsAt,
+    pomodoroStatus?.breakEndsAt,
+  ]);
+
+  const [displayedSeconds, setDisplayedSeconds] = useState(0);
+
+  useEffect(() => {
+    const tick = () => {
+      const next = getDisplayedStudySeconds(
+        studyTime,
+        Date.now(),
+        fetchedAtRef.current,
+      );
+      displayedSecondsRef.current = next;
+      setDisplayedSeconds(next);
+    };
+
+    tick();
+    if (!studyTime?.running) return;
+
+    const interval = window.setInterval(tick, 1000);
+    return () => window.clearInterval(interval);
+  }, [studyTime]);
+
+  const applyOptimistic = useCallback(
+    (next: MemberStudyTimeResponse) => {
+      fetchedAtRef.current = Date.now();
+      queryClient.setQueryData(QUERY_KEYS.studyTime.me, next);
+      const seconds = getDisplayedStudySeconds(
+        next,
+        Date.now(),
+        fetchedAtRef.current,
+      );
+      displayedSecondsRef.current = seconds;
+      setDisplayedSeconds(seconds);
+    },
+    [queryClient],
+  );
+
+  const flushDesired = useCallback(async () => {
+    if (inflightRef.current) return;
+    inflightRef.current = true;
+    setIsSyncing(true);
+
+    try {
+      while (desiredRunningRef.current !== null) {
+        const desired = desiredRunningRef.current;
+        desiredRunningRef.current = null;
+
+        try {
+          const data = desired
+            ? await resumeStudyTimeAsync()
+            : await pauseStudyTimeAsync();
+
+          const latestDesired = desiredRunningRef.current;
+          if (latestDesired !== null && latestDesired !== data.running) {
+            const current = queryClient.getQueryData<MemberStudyTimeResponse>(
+              QUERY_KEYS.studyTime.me,
+            );
+            applyOptimistic(
+              latestDesired
+                ? buildOptimisticRunning(current, displayedSecondsRef.current)
+                : buildOptimisticPaused(current, displayedSecondsRef.current),
+            );
+          } else {
+            fetchedAtRef.current = Date.now();
+            queryClient.setQueryData(QUERY_KEYS.studyTime.me, data);
+            const seconds = getDisplayedStudySeconds(
+              data,
+              Date.now(),
+              fetchedAtRef.current,
+            );
+            displayedSecondsRef.current = seconds;
+            setDisplayedSeconds(seconds);
+          }
+        } catch {
+          await queryClient.invalidateQueries({
+            queryKey: QUERY_KEYS.studyTime.me,
+          });
+          desiredRunningRef.current = null;
+          break;
+        }
+      }
+    } finally {
+      inflightRef.current = false;
+      setIsSyncing(false);
+
+      if (desiredRunningRef.current !== null) {
+        void flushDesired();
+      }
+    }
+  }, [
+    applyOptimistic,
+    pauseStudyTimeAsync,
+    queryClient,
+    resumeStudyTimeAsync,
+  ]);
+
+  const setDesiredRunning = useCallback(
+    (running: boolean) => {
+      desiredRunningRef.current = running;
+
+      const current = queryClient.getQueryData<MemberStudyTimeResponse>(
+        QUERY_KEYS.studyTime.me,
+      );
+      applyOptimistic(
+        running
+          ? buildOptimisticRunning(current, displayedSecondsRef.current)
+          : buildOptimisticPaused(current, displayedSecondsRef.current),
+      );
+
+      void flushDesired();
+    },
+    [applyOptimistic, flushDesired, queryClient],
+  );
+
+  const syncResume = useCallback(() => {
+    setDesiredRunning(true);
+  }, [setDesiredRunning]);
+
+  const syncPause = useCallback(() => {
+    setDesiredRunning(false);
+  }, [setDesiredRunning]);
+
+  const handleToggle = useCallback(() => {
+    const current = queryClient.getQueryData<MemberStudyTimeResponse>(
+      QUERY_KEYS.studyTime.me,
+    );
+    setDesiredRunning(!current?.running);
+  }, [queryClient, setDesiredRunning]);
+
+  useEffect(() => {
+    const reconcile = () => {
+      const phase = getPomodoroStudyPhase(
+        pomodoroStatus,
+        Date.now(),
+        pomodoroFetchedAtRef.current,
+      );
+      const prevPhase = prevPomodoroPhaseRef.current;
+
+      if (prevPhase === null) {
+        prevPomodoroPhaseRef.current = phase;
+        return;
+      }
+
+      if (prevPhase === phase) return;
+      prevPomodoroPhaseRef.current = phase;
+
+      if (shouldStudyTimerRunForPhase(phase)) {
+        syncResume();
+      } else {
+        syncPause();
+      }
+    };
+
+    reconcile();
+    const interval = window.setInterval(reconcile, 250);
+    return () => window.clearInterval(interval);
+  }, [pomodoroStatus, syncPause, syncResume]);
+
+  return {
+    studyTime,
+    displayedSeconds,
+    isRunning: !!studyTime?.running,
+    isLoading,
+    isFetching,
+    isTogglePending: isSyncing,
+    handleToggle,
+    syncResume,
+    syncPause,
+  };
+}

--- a/frontend/src/pages/Room/index.tsx
+++ b/frontend/src/pages/Room/index.tsx
@@ -16,7 +16,7 @@ const RoomPage = () => {
   const { groupCode } = useParams();
   const [todoOpen, setTodoOpen] = useState(false);
 
-  const { pomodoro, reactions, handleDataReceived } =
+  const { pomodoro, reactions, studyTime, handleDataReceived } =
     useRoomLiveKitData(groupCode);
 
   const {
@@ -39,6 +39,13 @@ const RoomPage = () => {
       <TopBar
         isTodoOpen={todoOpen}
         onToggleTodo={() => setTodoOpen((prev) => !prev)}
+        displayedStudySeconds={studyTime.displayedSeconds}
+        isStudyTimerRunning={studyTime.isRunning}
+        isStudyTimerPending={studyTime.isTogglePending}
+        onToggleStudyTimer={studyTime.handleToggle}
+        weeklyStudyTimeGoalSeconds={
+          studyTime.studyTime?.weeklyStudyTimeGoalSeconds
+        }
       />
 
       <div className="flex flex-1 overflow-hidden">

--- a/frontend/src/utils/pomodoroStudySync.ts
+++ b/frontend/src/utils/pomodoroStudySync.ts
@@ -2,10 +2,6 @@ import type { PomodoroStatusResponse } from "@/apis/domains/pomodoro/type";
 
 export type PomodoroStudyPhase = "focus" | "break" | "paused" | "idle";
 
-/**
- * 벽시계/endsAt 예측은 뽀모도로 UI(setInterval 카운트다운)보다
- * 먼저 멈추는 원인이 되므로, 서버가 내려준 status/phase만 신뢰한다.
- */
 export function getPomodoroStudyPhase(
   pomodoro: PomodoroStatusResponse | undefined,
 ): PomodoroStudyPhase {

--- a/frontend/src/utils/pomodoroStudySync.ts
+++ b/frontend/src/utils/pomodoroStudySync.ts
@@ -2,52 +2,21 @@ import type { PomodoroStatusResponse } from "@/apis/domains/pomodoro/type";
 
 export type PomodoroStudyPhase = "focus" | "break" | "paused" | "idle";
 
-function getAlignedServerNowMs(
-  serverNow: string,
-  clientNowMs: number,
-  fetchedAtMs?: number,
-): number {
-  const serverNowMs = Date.parse(serverNow);
-  if (Number.isNaN(serverNowMs)) return clientNowMs;
-  const anchorMs = fetchedAtMs ?? clientNowMs;
-  return serverNowMs + Math.max(0, clientNowMs - anchorMs);
-}
-
 /**
- * 뽀모도로 상태 + endsAt 시각으로 공부 타이머가 따라야 할 국면을 계산한다.
- * LiveKit phase 갱신이 늦어도 focusEndsAt/breakEndsAt 기준으로 전환을 감지한다.
+ * 벽시계/endsAt 예측은 뽀모도로 UI(setInterval 카운트다운)보다
+ * 먼저 멈추는 원인이 되므로, 서버가 내려준 status/phase만 신뢰한다.
  */
 export function getPomodoroStudyPhase(
   pomodoro: PomodoroStatusResponse | undefined,
-  clientNowMs: number = Date.now(),
-  fetchedAtMs?: number,
 ): PomodoroStudyPhase {
   if (!pomodoro) return "idle";
 
-  const { status, phase, focusEndsAt, breakEndsAt, serverNow } = pomodoro;
+  const { status, phase } = pomodoro;
 
   if (status === "IDLE" || status === "FINISHED") return "idle";
   if (status === "PAUSED") return "paused";
-
-  const nowMs = getAlignedServerNowMs(serverNow, clientNowMs, fetchedAtMs);
-  const focusEndMs = focusEndsAt ? Date.parse(focusEndsAt) : Number.NaN;
-  const breakEndMs = breakEndsAt ? Date.parse(breakEndsAt) : Number.NaN;
-
-  const focusEnded = !Number.isNaN(focusEndMs) && nowMs >= focusEndMs;
-  const breakEnded = !Number.isNaN(breakEndMs) && nowMs >= breakEndMs;
-
-  if (status === "BREAK" || phase === "BREAK") {
-    if (breakEnded) return "focus";
-    return "break";
-  }
-
-  if (status === "RUNNING") {
-    if (focusEnded) {
-      if (!Number.isNaN(breakEndMs)) {
-        return breakEnded ? "focus" : "break";
-      }
-      return "break";
-    }
+  if (status === "BREAK" || phase === "BREAK") return "break";
+  if (status === "RUNNING" && (phase === "FOCUS" || phase == null)) {
     return "focus";
   }
 

--- a/frontend/src/utils/pomodoroStudySync.ts
+++ b/frontend/src/utils/pomodoroStudySync.ts
@@ -1,0 +1,59 @@
+import type { PomodoroStatusResponse } from "@/apis/domains/pomodoro/type";
+
+export type PomodoroStudyPhase = "focus" | "break" | "paused" | "idle";
+
+function getAlignedServerNowMs(
+  serverNow: string,
+  clientNowMs: number,
+  fetchedAtMs?: number,
+): number {
+  const serverNowMs = Date.parse(serverNow);
+  if (Number.isNaN(serverNowMs)) return clientNowMs;
+  const anchorMs = fetchedAtMs ?? clientNowMs;
+  return serverNowMs + Math.max(0, clientNowMs - anchorMs);
+}
+
+/**
+ * 뽀모도로 상태 + endsAt 시각으로 공부 타이머가 따라야 할 국면을 계산한다.
+ * LiveKit phase 갱신이 늦어도 focusEndsAt/breakEndsAt 기준으로 전환을 감지한다.
+ */
+export function getPomodoroStudyPhase(
+  pomodoro: PomodoroStatusResponse | undefined,
+  clientNowMs: number = Date.now(),
+  fetchedAtMs?: number,
+): PomodoroStudyPhase {
+  if (!pomodoro) return "idle";
+
+  const { status, phase, focusEndsAt, breakEndsAt, serverNow } = pomodoro;
+
+  if (status === "IDLE" || status === "FINISHED") return "idle";
+  if (status === "PAUSED") return "paused";
+
+  const nowMs = getAlignedServerNowMs(serverNow, clientNowMs, fetchedAtMs);
+  const focusEndMs = focusEndsAt ? Date.parse(focusEndsAt) : Number.NaN;
+  const breakEndMs = breakEndsAt ? Date.parse(breakEndsAt) : Number.NaN;
+
+  const focusEnded = !Number.isNaN(focusEndMs) && nowMs >= focusEndMs;
+  const breakEnded = !Number.isNaN(breakEndMs) && nowMs >= breakEndMs;
+
+  if (status === "BREAK" || phase === "BREAK") {
+    if (breakEnded) return "focus";
+    return "break";
+  }
+
+  if (status === "RUNNING") {
+    if (focusEnded) {
+      if (!Number.isNaN(breakEndMs)) {
+        return breakEnded ? "focus" : "break";
+      }
+      return "break";
+    }
+    return "focus";
+  }
+
+  return "idle";
+}
+
+export function shouldStudyTimerRunForPhase(phase: PomodoroStudyPhase): boolean {
+  return phase === "focus";
+}

--- a/frontend/src/utils/studyTime.ts
+++ b/frontend/src/utils/studyTime.ts
@@ -1,0 +1,40 @@
+import type { MemberStudyTimeResponse } from "@/apis/domains/studyTime/type";
+
+export function formatStudySecondsAsClock(totalSeconds: number): string {
+  const safe = Math.max(0, Math.floor(totalSeconds));
+  const h = Math.floor(safe / 3600);
+  const m = Math.floor((safe % 3600) / 60);
+  const s = safe % 60;
+  return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+export function getDisplayedStudySeconds(
+  studyTime: MemberStudyTimeResponse | undefined,
+  clientNowMs: number = Date.now(),
+  fetchedAtMs?: number,
+): number {
+  if (!studyTime) return 0;
+
+  const base = Math.max(0, studyTime.currentWeekStudyTimeSeconds);
+  if (!studyTime.running || !studyTime.lastStartedAt) return base;
+
+  const serverNowMs = Date.parse(studyTime.serverNow);
+  const lastStartedMs = Date.parse(studyTime.lastStartedAt);
+  if (Number.isNaN(serverNowMs) || Number.isNaN(lastStartedMs)) return base;
+
+  const anchorMs = fetchedAtMs ?? clientNowMs;
+  const serverElapsedAtFetchMs = Math.max(0, serverNowMs - lastStartedMs);
+  const clientElapsedSinceFetchMs = Math.max(0, clientNowMs - anchorMs);
+
+  return (
+    base + Math.floor((serverElapsedAtFetchMs + clientElapsedSinceFetchMs) / 1000)
+  );
+}
+
+export function getStudyTimeProgressPercent(
+  currentSeconds: number,
+  goalSeconds: number | null | undefined,
+): number {
+  if (goalSeconds == null || goalSeconds <= 0) return 0;
+  return Math.min(100, (currentSeconds / goalSeconds) * 100);
+}

--- a/frontend/src/utils/studyTime.ts
+++ b/frontend/src/utils/studyTime.ts
@@ -36,5 +36,5 @@ export function getStudyTimeProgressPercent(
   goalSeconds: number | null | undefined,
 ): number {
   if (goalSeconds == null || goalSeconds <= 0) return 0;
-  return Math.min(100, (currentSeconds / goalSeconds) * 100);
+  return Math.max(0, Math.min(100, (currentSeconds / goalSeconds) * 100));
 }


### PR DESCRIPTION
# 변경점 👍
- 개인 공부 타이머 API 연동 (`GET` / `resume` / `pause`)
- 방 입장 시 GET으로 누적 시간 표시, TopBar 재생·일시정지 토글
- 뽀모도로 실제 국면(공부/쉬는시간/일시정지/정지)에 맞춰 타이머 자동 시작·정지
- 연속 클릭 시 마지막 의도만 반영되도록 요청 큐 처리
- 그룹 카드 hover/클릭 시 study-time prefetch
- 홈 프로필 주간 공부 진행바 연동