### PR TITLE
feat: 다른 LiveKit 방 참여 여부 조회 API 추가 (현재 방 제외)

### DIFF
--- a/backend/grit/src/main/java/grit/domain/group/livekit/controller/LiveKitController.java
+++ b/backend/grit/src/main/java/grit/domain/group/livekit/controller/LiveKitController.java
@@ -3,6 +3,7 @@ package grit.domain.group.livekit.controller;
 import grit.domain.auth.infrastructure.jwt.MemberPrincipal;
 import grit.domain.group.livekit.constraint.ReactionEmoji;
 import grit.domain.group.livekit.dto.LiveKitReactionRequestDto;
+import grit.domain.group.livekit.dto.OtherRoomParticipationResponseDto;
 import grit.domain.group.livekit.dto.SupportReactionsResponseDto;
 import grit.domain.group.livekit.service.LiveKitService;
 import grit.domain.member.entity.Member;
@@ -63,12 +64,13 @@ public class LiveKitController {
             @ApiResponse(responseCode = "403", description = "그룹 멤버가 아님")
     })
     @GetMapping("/other-room")
-    public ResponseEntity<Boolean> isParticipatingInOtherRoom(
+    public ResponseEntity<OtherRoomParticipationResponseDto> isParticipatingInOtherRoom(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
             @PathVariable String groupCode) {
 
         Member member = memberService.findMemberById(memberPrincipal.id());
-        return ResponseEntity.ok(liveKitService.isParticipatingInOtherRoom(member, groupCode));
+        boolean isInOtherRoom = liveKitService.isParticipatingInOtherRoom(member, groupCode);
+        return ResponseEntity.ok(new OtherRoomParticipationResponseDto(isInOtherRoom));
     }
 
     @GetMapping("/reactions")

--- a/backend/grit/src/main/java/grit/domain/group/livekit/controller/LiveKitController.java
+++ b/backend/grit/src/main/java/grit/domain/group/livekit/controller/LiveKitController.java
@@ -54,6 +54,23 @@ public class LiveKitController {
         return ResponseEntity.ok(Map.of("token", token.toJwt()));
     }
 
+    @Operation(
+            summary = "다른 LiveKit 방 참여 여부 조회",
+            description = "현재 그룹 방을 제외한 다른 그룹 방에 참여 중인지 true/false로 반환합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "그룹 멤버가 아님")
+    })
+    @GetMapping("/other-room")
+    public ResponseEntity<Boolean> isParticipatingInOtherRoom(
+            @AuthenticationPrincipal MemberPrincipal memberPrincipal,
+            @PathVariable String groupCode) {
+
+        Member member = memberService.findMemberById(memberPrincipal.id());
+        return ResponseEntity.ok(liveKitService.isParticipatingInOtherRoom(member, groupCode));
+    }
+
     @GetMapping("/reactions")
     public ResponseEntity<List<SupportReactionsResponseDto>> getSupportReactions() {
 

--- a/backend/grit/src/main/java/grit/domain/group/livekit/dto/OtherRoomParticipationResponseDto.java
+++ b/backend/grit/src/main/java/grit/domain/group/livekit/dto/OtherRoomParticipationResponseDto.java
@@ -1,0 +1,12 @@
+package grit.domain.group.livekit.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record OtherRoomParticipationResponseDto(
+        @Schema(
+                description = "현재 그룹 방을 제외한 다른 LiveKit 그룹 방 참여 여부",
+                example = "true"
+        )
+        boolean isInOtherRoom
+) {
+}

--- a/backend/grit/src/main/java/grit/domain/group/livekit/service/LiveKitRoomStatusService.java
+++ b/backend/grit/src/main/java/grit/domain/group/livekit/service/LiveKitRoomStatusService.java
@@ -2,16 +2,19 @@ package grit.domain.group.livekit.service;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import livekit.LivekitWebhook.WebhookEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -21,10 +24,85 @@ public class LiveKitRoomStatusService {
     private static final String ROOM_NAME_PREFIX = "group:";
     private static final String PARTICIPANTS_KEY_PREFIX = "livekit:room:";
     private static final String PARTICIPANTS_KEY_SUFFIX = ":participants";
+    private static final String CONNECTIONS_KEY_SUFFIX = ":connections";
+    private static final String PARTICIPANT_ROOMS_KEY_PREFIX = "livekit:participant:";
+    private static final String PARTICIPANT_ROOMS_KEY_SUFFIX = ":rooms";
+    private static final String PARTICIPANT_ROOMS_INDEXED_KEY_SUFFIX = ":indexed";
     private static final String EVENT_PARTICIPANT_JOINED = "participant_joined";
     private static final String EVENT_PARTICIPANT_LEFT = "participant_left";
     private static final String EVENT_ROOM_FINISHED = "room_finished";
     private static final Duration STATUS_TTL = Duration.ofHours(24);
+    private static final DefaultRedisScript<Long> ADD_PARTICIPANT_SCRIPT = new DefaultRedisScript<>("""
+            redis.call('SADD', KEYS[1], ARGV[1])
+            redis.call('EXPIRE', KEYS[1], ARGV[4])
+            redis.call('SADD', KEYS[2], ARGV[2])
+            redis.call('EXPIRE', KEYS[2], ARGV[4])
+            redis.call('HSET', KEYS[3], ARGV[1], ARGV[3])
+            redis.call('EXPIRE', KEYS[3], ARGV[4])
+            redis.call('SET', KEYS[4], '1', 'EX', ARGV[4])
+            return 1
+            """, Long.class);
+    private static final DefaultRedisScript<Long> REMOVE_PARTICIPANT_SCRIPT = new DefaultRedisScript<>("""
+            local currentSid = redis.call('HGET', KEYS[3], ARGV[1])
+            if currentSid and currentSid ~= ARGV[3] then
+                return -1
+            end
+            redis.call('SREM', KEYS[1], ARGV[1])
+            redis.call('SREM', KEYS[2], ARGV[2])
+            redis.call('HDEL', KEYS[3], ARGV[1])
+            if redis.call('SCARD', KEYS[2]) == 0 then
+                redis.call('DEL', KEYS[2])
+            end
+            local remainingParticipants = redis.call('SCARD', KEYS[1])
+            if remainingParticipants == 0 then
+                redis.call('DEL', KEYS[1])
+                redis.call('DEL', KEYS[3])
+            end
+            redis.call('SET', KEYS[4], '1', 'EX', ARGV[4])
+            return remainingParticipants
+            """, Long.class);
+    private static final DefaultRedisScript<Long> FINISH_ROOM_SCRIPT = new DefaultRedisScript<>("""
+            local identities = redis.call('SMEMBERS', KEYS[1])
+            for _, identity in ipairs(identities) do
+                local participantRoomsKey = ARGV[2] .. identity .. ARGV[3]
+                redis.call('SREM', participantRoomsKey, ARGV[1])
+                if redis.call('SCARD', participantRoomsKey) == 0 then
+                    redis.call('DEL', participantRoomsKey)
+                end
+            end
+            redis.call('DEL', KEYS[1])
+            redis.call('DEL', KEYS[2])
+            return #identities
+            """, Long.class);
+    private static final DefaultRedisScript<Long> HAS_OTHER_ROOM_SCRIPT = new DefaultRedisScript<>("""
+            if redis.call('EXISTS', KEYS[2]) == 0 then
+                return -1
+            end
+            local roomCount = redis.call('SCARD', KEYS[1])
+            if roomCount == 0 then
+                return 0
+            end
+            if roomCount > 1 then
+                return 1
+            end
+            if redis.call('SISMEMBER', KEYS[1], ARGV[1]) == 1 then
+                return 0
+            end
+            return 1
+            """, Long.class);
+    private static final DefaultRedisScript<Long> BACKFILL_PARTICIPANT_ROOMS_SCRIPT = new DefaultRedisScript<>("""
+            if redis.call('EXISTS', KEYS[2]) == 1 then
+                return 0
+            end
+            for index = 2, #ARGV do
+                redis.call('SADD', KEYS[1], ARGV[index])
+            end
+            if #ARGV > 1 then
+                redis.call('EXPIRE', KEYS[1], ARGV[1])
+            end
+            redis.call('SET', KEYS[2], '1', 'EX', ARGV[1])
+            return 1
+            """, Long.class);
 
     private final StringRedisTemplate redisTemplate;
 
@@ -46,7 +124,7 @@ public class LiveKitRoomStatusService {
                 }
                 case EVENT_PARTICIPANT_LEFT -> removeParticipant(roomName, event);
                 case EVENT_ROOM_FINISHED -> {
-                    redisTemplate.delete(participantsKey(roomName));
+                    finishRoom(roomName);
                     yield Optional.empty();
                 }
                 default -> Optional.empty();
@@ -93,6 +171,32 @@ public class LiveKitRoomStatusService {
         return participantCounts;
     }
 
+    public boolean isParticipatingInOtherRoom(
+            String identity,
+            String currentGroupCode,
+            Supplier<? extends Collection<String>> memberGroupCodesSupplier
+    ) {
+        String participantRoomsKey = participantRoomsKey(identity);
+        String participantRoomsIndexedKey = participantRoomsIndexedKey(identity);
+        Long result = redisTemplate.execute(
+                HAS_OTHER_ROOM_SCRIPT,
+                List.of(participantRoomsKey, participantRoomsIndexedKey),
+                roomName(currentGroupCode)
+        );
+        if (result == null) {
+            throw new IllegalStateException("LiveKit room participation lookup returned no result.");
+        }
+        if (!Long.valueOf(-1L).equals(result)) {
+            return Long.valueOf(1L).equals(result);
+        }
+
+        List<String> joinedRoomNames =
+                findJoinedRoomsFromLegacyIndex(identity, memberGroupCodesSupplier.get());
+        backfillParticipantRooms(participantRoomsKey, participantRoomsIndexedKey, joinedRoomNames);
+        String currentRoomName = roomName(currentGroupCode);
+        return joinedRoomNames.stream().anyMatch(joinedRoomName -> !joinedRoomName.equals(currentRoomName));
+    }
+
     private void addParticipant(String roomName, WebhookEvent event) {
         if (!event.hasParticipant()) {
             return;
@@ -103,8 +207,19 @@ public class LiveKitRoomStatusService {
             return;
         }
 
-        redisTemplate.opsForSet().add(participantsKey(roomName), identity);
-        redisTemplate.expire(participantsKey(roomName), STATUS_TTL);
+        redisTemplate.execute(
+                ADD_PARTICIPANT_SCRIPT,
+                List.of(
+                        participantsKey(roomName),
+                        participantRoomsKey(identity),
+                        connectionsKey(roomName),
+                        participantRoomsIndexedKey(identity)
+                ),
+                identity,
+                roomName,
+                event.getParticipant().getSid(),
+                String.valueOf(STATUS_TTL.toSeconds())
+        );
     }
 
     private Optional<String> removeParticipant(String roomName, WebhookEvent event) {
@@ -117,13 +232,80 @@ public class LiveKitRoomStatusService {
             return Optional.empty();
         }
 
-        String key = participantsKey(roomName);
-        redisTemplate.opsForSet().remove(key, identity);
-        Long remainingParticipants = redisTemplate.opsForSet().size(key);
-        if (remainingParticipants != null && remainingParticipants == 0) {
+        Long remainingParticipants = redisTemplate.execute(
+                REMOVE_PARTICIPANT_SCRIPT,
+                List.of(
+                        participantsKey(roomName),
+                        participantRoomsKey(identity),
+                        connectionsKey(roomName),
+                        participantRoomsIndexedKey(identity)
+                ),
+                identity,
+                roomName,
+                event.getParticipant().getSid(),
+                String.valueOf(STATUS_TTL.toSeconds())
+        );
+        if (Long.valueOf(0L).equals(remainingParticipants)) {
             return Optional.of(roomName.substring(ROOM_NAME_PREFIX.length()));
         }
         return Optional.empty();
+    }
+
+    private void finishRoom(String roomName) {
+        redisTemplate.execute(
+                FINISH_ROOM_SCRIPT,
+                List.of(participantsKey(roomName), connectionsKey(roomName)),
+                roomName,
+                PARTICIPANT_ROOMS_KEY_PREFIX,
+                PARTICIPANT_ROOMS_KEY_SUFFIX
+        );
+    }
+
+    private List<String> findJoinedRoomsFromLegacyIndex(
+            String identity,
+            Collection<String> memberGroupCodes
+    ) {
+        List<String> roomNames = memberGroupCodes.stream()
+                .distinct()
+                .map(this::roomName)
+                .toList();
+        if (roomNames.isEmpty()) {
+            return List.of();
+        }
+
+        byte[] identityBytes = identity.getBytes(StandardCharsets.UTF_8);
+        List<Object> results = redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+            for (String candidateRoomName : roomNames) {
+                connection.setCommands().sIsMember(
+                        participantsKey(candidateRoomName).getBytes(StandardCharsets.UTF_8),
+                        identityBytes
+                );
+            }
+            return null;
+        });
+
+        List<String> joinedRoomNames = new ArrayList<>();
+        for (int i = 0; i < roomNames.size(); i++) {
+            if (Boolean.TRUE.equals(results.get(i))) {
+                joinedRoomNames.add(roomNames.get(i));
+            }
+        }
+        return joinedRoomNames;
+    }
+
+    private void backfillParticipantRooms(
+            String participantRoomsKey,
+            String participantRoomsIndexedKey,
+            List<String> joinedRoomNames
+    ) {
+        List<String> arguments = new ArrayList<>();
+        arguments.add(String.valueOf(STATUS_TTL.toSeconds()));
+        arguments.addAll(joinedRoomNames);
+        redisTemplate.execute(
+                BACKFILL_PARTICIPANT_ROOMS_SCRIPT,
+                List.of(participantRoomsKey, participantRoomsIndexedKey),
+                arguments.toArray()
+        );
     }
 
     private String roomName(String groupCode) {
@@ -132,5 +314,17 @@ public class LiveKitRoomStatusService {
 
     private String participantsKey(String roomName) {
         return PARTICIPANTS_KEY_PREFIX + roomName + PARTICIPANTS_KEY_SUFFIX;
+    }
+
+    private String connectionsKey(String roomName) {
+        return PARTICIPANTS_KEY_PREFIX + roomName + CONNECTIONS_KEY_SUFFIX;
+    }
+
+    private String participantRoomsKey(String identity) {
+        return PARTICIPANT_ROOMS_KEY_PREFIX + identity + PARTICIPANT_ROOMS_KEY_SUFFIX;
+    }
+
+    private String participantRoomsIndexedKey(String identity) {
+        return participantRoomsKey(identity) + PARTICIPANT_ROOMS_INDEXED_KEY_SUFFIX;
     }
 }

--- a/backend/grit/src/main/java/grit/domain/group/livekit/service/LiveKitService.java
+++ b/backend/grit/src/main/java/grit/domain/group/livekit/service/LiveKitService.java
@@ -45,6 +45,7 @@ public class LiveKitService {
     private final ObjectMapper objectMapper;
     private final Clock clock;
     private final ObservationRegistry observationRegistry;
+    private final LiveKitRoomStatusService liveKitRoomStatusService;
     private RoomServiceClient client;
 
     @PostConstruct
@@ -67,6 +68,19 @@ public class LiveKitService {
                 new CanPublishData(false)
         );
         return token;
+    }
+
+    public boolean isParticipatingInOtherRoom(Member member, String groupCode) {
+        Group group = groupService.findGroupByCode(groupCode);
+        checkPermission(member, group);
+
+        return liveKitRoomStatusService.isParticipatingInOtherRoom(
+                member.getNickname(),
+                group.getCode(),
+                () -> groupService.getMyGroups(member).stream()
+                        .map(Group::getCode)
+                        .toList()
+        );
     }
 
     public void sendReaction(Member member, String groupCode, ReactionEmoji emoji) {

--- a/backend/grit/src/test/java/grit/domain/group/livekit/dto/OtherRoomParticipationResponseDtoTest.java
+++ b/backend/grit/src/test/java/grit/domain/group/livekit/dto/OtherRoomParticipationResponseDtoTest.java
@@ -1,0 +1,21 @@
+package grit.domain.group.livekit.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class OtherRoomParticipationResponseDtoTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void serializesBooleanInsideJsonObject() {
+        OtherRoomParticipationResponseDto response =
+                new OtherRoomParticipationResponseDto(true);
+
+        String json = objectMapper.writeValueAsString(response);
+
+        assertThat(json).isEqualTo("{\"isInOtherRoom\":true}");
+    }
+}

--- a/backend/grit/src/test/java/grit/domain/group/livekit/service/LiveKitRoomStatusServiceTest.java
+++ b/backend/grit/src/test/java/grit/domain/group/livekit/service/LiveKitRoomStatusServiceTest.java
@@ -1,57 +1,240 @@
 package grit.domain.group.livekit.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Optional;
+import java.util.List;
 import livekit.LivekitModels.ParticipantInfo;
 import livekit.LivekitModels.Room;
 import livekit.LivekitWebhook.WebhookEvent;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.SetOperations;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings({"rawtypes", "unchecked"})
 class LiveKitRoomStatusServiceTest {
-
-    private static final String PARTICIPANTS_KEY = "livekit:room:group:ABC123:participants";
 
     @Mock
     private StringRedisTemplate redisTemplate;
 
-    @Mock
-    private SetOperations<String, String> setOperations;
+    private LiveKitRoomStatusService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LiveKitRoomStatusService(redisTemplate);
+    }
+
+    @Test
+    void currentRoomIsExcludedFromOtherRoomParticipation() {
+        when(redisTemplate.execute(
+                any(RedisScript.class),
+                eq(List.of(
+                        "livekit:participant:member:rooms",
+                        "livekit:participant:member:rooms:indexed"
+                )),
+                eq("group:CURRENT")
+        )).thenReturn(0L);
+
+        boolean result = service.isParticipatingInOtherRoom(
+                "member",
+                "CURRENT",
+                () -> {
+                    throw new AssertionError("fast path must not load group memberships");
+                }
+        );
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void returnsTrueWhenReverseIndexContainsAnotherRoom() {
+        when(redisTemplate.execute(
+                any(RedisScript.class),
+                eq(List.of(
+                        "livekit:participant:member:rooms",
+                        "livekit:participant:member:rooms:indexed"
+                )),
+                eq("group:CURRENT")
+        )).thenReturn(1L);
+
+        boolean result = service.isParticipatingInOtherRoom(
+                "member",
+                "CURRENT",
+                () -> {
+                    throw new AssertionError("fast path must not load group memberships");
+                }
+        );
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void redisFailureIsPropagatedInsteadOfReturningFalse() {
+        when(redisTemplate.execute(
+                any(RedisScript.class),
+                eq(List.of(
+                        "livekit:participant:member:rooms",
+                        "livekit:participant:member:rooms:indexed"
+                )),
+                eq("group:CURRENT")
+        ))
+                .thenThrow(new QueryTimeoutException("timeout"));
+
+        assertThatThrownBy(() ->
+                service.isParticipatingInOtherRoom("member", "CURRENT", List::of))
+                .isInstanceOf(QueryTimeoutException.class);
+    }
+
+    @Test
+    void missingReverseIndexIsBackfilledFromExistingRoomIndexes() {
+        when(redisTemplate.execute(
+                any(RedisScript.class),
+                eq(List.of(
+                        "livekit:participant:member:rooms",
+                        "livekit:participant:member:rooms:indexed"
+                )),
+                eq("group:CURRENT")
+        )).thenReturn(-1L);
+        when(redisTemplate.executePipelined(any(RedisCallback.class)))
+                .thenReturn(List.of(false, true));
+
+        boolean result = service.isParticipatingInOtherRoom(
+                "member",
+                "CURRENT",
+                () -> List.of("CURRENT", "OTHER")
+        );
+
+        assertThat(result).isTrue();
+        verify(redisTemplate).execute(
+                any(RedisScript.class),
+                eq(List.of(
+                        "livekit:participant:member:rooms",
+                        "livekit:participant:member:rooms:indexed"
+                )),
+                eq("86400"),
+                eq("group:OTHER")
+        );
+    }
+
+    @Test
+    void joinedEventAtomicallyUpdatesRoomAndParticipantIndexes() {
+        WebhookEvent event = participantEvent("participant_joined", "group:CURRENT", "member", "PA_1");
+
+        service.applyWebhookEvent(event);
+
+        verify(redisTemplate).execute(
+                any(RedisScript.class),
+                eq(List.of(
+                        "livekit:room:group:CURRENT:participants",
+                        "livekit:participant:member:rooms",
+                        "livekit:room:group:CURRENT:connections",
+                        "livekit:participant:member:rooms:indexed"
+                )),
+                eq("member"),
+                eq("group:CURRENT"),
+                eq("PA_1"),
+                eq("86400")
+        );
+    }
+
+    @Test
+    void leftEventPassesConnectionSidForStaleEventProtection() {
+        WebhookEvent event = participantEvent("participant_left", "group:CURRENT", "member", "PA_1");
+
+        service.applyWebhookEvent(event);
+
+        verify(redisTemplate).execute(
+                any(RedisScript.class),
+                eq(List.of(
+                        "livekit:room:group:CURRENT:participants",
+                        "livekit:participant:member:rooms",
+                        "livekit:room:group:CURRENT:connections",
+                        "livekit:participant:member:rooms:indexed"
+                )),
+                eq("member"),
+                eq("group:CURRENT"),
+                eq("PA_1"),
+                eq("86400")
+        );
+    }
 
     @Test
     void participantLeftReturnsGroupCodeWhenRoomBecomesEmpty() {
-        LiveKitRoomStatusService service = new LiveKitRoomStatusService(redisTemplate);
-        when(redisTemplate.opsForSet()).thenReturn(setOperations);
-        when(setOperations.size(PARTICIPANTS_KEY)).thenReturn(0L);
+        WebhookEvent event = participantEvent("participant_left", "group:ABC123", "member", "PA_1");
+        when(redisTemplate.execute(
+                any(RedisScript.class),
+                eq(List.of(
+                        "livekit:room:group:ABC123:participants",
+                        "livekit:participant:member:rooms",
+                        "livekit:room:group:ABC123:connections",
+                        "livekit:participant:member:rooms:indexed"
+                )),
+                eq("member"),
+                eq("group:ABC123"),
+                eq("PA_1"),
+                eq("86400")
+        )).thenReturn(0L);
 
-        Optional<String> emptyRoomGroupCode = service.applyWebhookEvent(participantLeftEvent());
-
-        assertThat(emptyRoomGroupCode).contains("ABC123");
+        assertThat(service.applyWebhookEvent(event)).contains("ABC123");
     }
 
     @Test
     void participantLeftDoesNotReturnGroupCodeWhenParticipantRemains() {
-        LiveKitRoomStatusService service = new LiveKitRoomStatusService(redisTemplate);
-        when(redisTemplate.opsForSet()).thenReturn(setOperations);
-        when(setOperations.size(PARTICIPANTS_KEY)).thenReturn(1L);
+        WebhookEvent event = participantEvent("participant_left", "group:ABC123", "member", "PA_1");
+        when(redisTemplate.execute(
+                any(RedisScript.class),
+                eq(List.of(
+                        "livekit:room:group:ABC123:participants",
+                        "livekit:participant:member:rooms",
+                        "livekit:room:group:ABC123:connections",
+                        "livekit:participant:member:rooms:indexed"
+                )),
+                eq("member"),
+                eq("group:ABC123"),
+                eq("PA_1"),
+                eq("86400")
+        )).thenReturn(1L);
 
-        Optional<String> emptyRoomGroupCode = service.applyWebhookEvent(participantLeftEvent());
-
-        assertThat(emptyRoomGroupCode).isEmpty();
+        assertThat(service.applyWebhookEvent(event)).isEmpty();
     }
 
-    private WebhookEvent participantLeftEvent() {
+    @Test
+    void ignoresEventsOutsideManagedGroupRooms() {
+        WebhookEvent event = participantEvent("participant_joined", "external-room", "member", "PA_1");
+
+        service.applyWebhookEvent(event);
+
+        verify(redisTemplate, never()).execute(
+                any(RedisScript.class),
+                any(),
+                any()
+        );
+    }
+
+    private WebhookEvent participantEvent(
+            String eventName,
+            String roomName,
+            String identity,
+            String participantSid
+    ) {
         return WebhookEvent.newBuilder()
-                .setEvent("participant_left")
-                .setRoom(Room.newBuilder().setName("group:ABC123"))
-                .setParticipant(ParticipantInfo.newBuilder().setIdentity("member"))
+                .setEvent(eventName)
+                .setRoom(Room.newBuilder().setName(roomName))
+                .setParticipant(ParticipantInfo.newBuilder()
+                        .setIdentity(identity)
+                        .setSid(participantSid))
                 .build();
     }
 }

--- a/backend/grit/src/test/java/grit/domain/group/livekit/service/LiveKitServiceTest.java
+++ b/backend/grit/src/test/java/grit/domain/group/livekit/service/LiveKitServiceTest.java
@@ -1,0 +1,87 @@
+package grit.domain.group.livekit.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import grit.domain.group.GroupService;
+import grit.domain.group.entity.Group;
+import grit.domain.member.entity.Member;
+import io.micrometer.observation.ObservationRegistry;
+import java.time.Clock;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class LiveKitServiceTest {
+
+    @Mock
+    private GroupService groupService;
+
+    @Mock
+    private LiveKitRoomStatusService liveKitRoomStatusService;
+
+    private LiveKitService liveKitService;
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        liveKitService = new LiveKitService(
+                groupService,
+                new ObjectMapper(),
+                Clock.systemUTC(),
+                ObservationRegistry.NOOP,
+                liveKitRoomStatusService
+        );
+        ReflectionTestUtils.setField(liveKitService, "apiKey", "api-key");
+        ReflectionTestUtils.setField(liveKitService, "apiSecret", "api-secret");
+
+        member = Member.builder()
+                .id(1L)
+                .nickname("grit-user")
+                .email("grit@example.com")
+                .build();
+
+        Group group = mock(Group.class);
+        when(group.getCode()).thenReturn("CURRENT");
+        when(groupService.findGroupByCode("CURRENT")).thenReturn(group);
+        when(groupService.isMemberInGroup(member, group)).thenReturn(true);
+    }
+
+    @Test
+    void returnsFalseWhenMemberIsOnlyInCurrentRoom() {
+        when(liveKitRoomStatusService.isParticipatingInOtherRoom(
+                eq("grit-user"),
+                eq("CURRENT"),
+                any(Supplier.class)
+        ))
+                .thenReturn(false);
+
+        boolean result = liveKitService.isParticipatingInOtherRoom(member, "CURRENT");
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void returnsTrueWhenMemberIsInAnotherRoom() {
+        when(liveKitRoomStatusService.isParticipatingInOtherRoom(
+                eq("grit-user"),
+                eq("CURRENT"),
+                any(Supplier.class)
+        ))
+                .thenReturn(true);
+
+        boolean result = liveKitService.isParticipatingInOtherRoom(member, "CURRENT");
+
+        assertThat(result).isTrue();
+    }
+}


### PR DESCRIPTION
# 변경점 👍

- 현재 방을 제외한 다른 LiveKit 방 참여 여부 조회 API 추가
  - `GET /api/group/{groupCode}/livekit/other-room`
  - 응답: `{ "isInOtherRoom": true | false }`